### PR TITLE
Add initial CORS

### DIFF
--- a/ir_api/ir_api.py
+++ b/ir_api/ir_api.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from fastapi import FastAPI, Request
 from starlette.background import BackgroundTasks
+from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse
 
 from ir_api.core.exceptions import MissingRecordError, MissingScriptError
@@ -24,6 +25,17 @@ logger = logging.getLogger(__name__)
 
 
 app = FastAPI()
+
+# This must be updated before exposing outside the vpn
+ALLOWED_ORIGINS = ["*"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.exception_handler(MissingRecordError)


### PR DESCRIPTION
Closes #9 

## Description
This adds the initial CORS option allowing requests from external origins, without this, the API can only recieve requests from the same origin.

@Pasarus We will need to collaborate in the future to determine the exact origins based from K8s, and the domain of the frontend to keep the allowed origins list up to date.