### PR TITLE
Add new endpoints

### DIFF
--- a/ir_api/core/services/run.py
+++ b/ir_api/core/services/run.py
@@ -30,7 +30,9 @@ def get_runs_by_instrument(
     instrument: str,
     limit: int = 0,
     offset: int = 0,
-    order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
+    order_by: Literal[
+        "experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id", "filename"
+    ] = "run_start",
     order_direction: Literal["asc", "desc"] = "desc",
 ) -> Sequence[Run]:
     """

--- a/ir_api/core/services/run.py
+++ b/ir_api/core/services/run.py
@@ -1,0 +1,51 @@
+"""
+Service Layer for runs
+"""
+from typing import Sequence, Literal
+
+from ir_api.core.model import Instrument, Run
+from ir_api.core.repositories import RunRepo
+
+_RUN_REPO = RunRepo()
+
+
+def get_total_run_count() -> int:
+    """
+    Get the total number of runs
+    :return: The number of runs
+    """
+    return _RUN_REPO.count()
+
+
+def get_run_count_by_instrument(instrument: str) -> int:
+    """
+    Get the total number of runs for the given instrument
+    :param instrument: The instrument
+    :return: The number of runs
+    """
+    return _RUN_REPO.count(lambda run: run.instrument.has(Instrument.instrument_name == instrument))
+
+
+def get_runs_by_instrument(
+    instrument: str,
+    limit: int = 0,
+    offset: int = 0,
+    order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
+    order_direction: Literal["asc", "desc"] = "desc",
+) -> Sequence[Run]:
+    """
+    Get the runs for the given instrument
+    :param instrument: Instrument name
+    :param limit: optional limit to be applied
+    :param offset: optional offset to be applied
+    :param order_by: optional field to order by
+    :param order_direction: optional direction to order by in
+    :return: The sequence of runs
+    """
+    return _RUN_REPO.find(
+        lambda run: run.instrument.has(Instrument.instrument_name == instrument),
+        limit=limit,
+        offset=offset,
+        order_by=order_by,
+        order_direction=order_direction,
+    )

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -11,6 +11,7 @@ from ir_api.core.responses import (
     ReductionResponse,
     ReductionWithRunsResponse,
     CountResponse,
+    RunResponse,
 )
 from ir_api.core.services.reduction import (
     get_reductions_by_instrument,
@@ -19,6 +20,7 @@ from ir_api.core.services.reduction import (
     count_reductions,
     count_reductions_by_instrument,
 )
+from ir_api.core.services.run import get_total_run_count, get_run_count_by_instrument, get_runs_by_instrument
 from ir_api.scripts.acquisition import (
     get_script_for_reduction,
     write_script_locally,
@@ -151,3 +153,39 @@ async def count_all_reductions() -> CountResponse:
     :return: CountResponse containing the count
     """
     return CountResponse(count=count_reductions())
+
+
+@ROUTER.get("/runs/count")
+async def count_all_runs() -> CountResponse:
+    """
+    Count all runs
+    :return: Count response containing the count
+    """
+    return CountResponse(count=get_total_run_count())
+
+
+@ROUTER.get("/instrument/{instrument}/runs/count")
+async def count_runs_for_instrument(instrument: str) -> CountResponse:
+    """
+    Count the total runs for the given instrument
+    :param instrument: The instrument
+    :return: The count response
+    """
+    instrument = instrument.upper()
+    return CountResponse(count=get_run_count_by_instrument(instrument))
+
+
+@ROUTER.get("/instrument/{instrument}/runs")
+async def get_runs_for_instrument(
+    instrument: str,
+    limit: int = 0,
+    offset: int = 0,
+    order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
+    order_direction: Literal["asc", "desc"] = "desc",
+) -> List[RunResponse]:
+    return [
+        RunResponse.from_run(run)
+        for run in get_runs_by_instrument(
+            instrument.upper(), limit=limit, offset=offset, order_by=order_by, order_direction=order_direction
+        )
+    ]

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -183,6 +183,15 @@ async def get_runs_for_instrument(
     order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
     order_direction: Literal["asc", "desc"] = "desc",
 ) -> List[RunResponse]:
+    """
+    Get all runs for the given instrument
+    :param instrument: The instrument
+    :param limit: Optional limit to apply
+    :param offset: Optional offset to apply
+    :param order_by: Optional field to order by
+    :param order_direction: Optional direction to order by
+    :return: List of RunResponses
+    """
     return [
         RunResponse.from_run(run)
         for run in get_runs_by_instrument(

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -83,7 +83,7 @@ async def get_reductions_for_instrument(
     order_by: Literal["reduction_start", "reduction_end", "reduction_state", "id"] = "reduction_start",
     order_direction: Literal["asc", "desc"] = "desc",
     include_runs: bool = False,
-) -> List[ReductionResponse]:
+) -> List[ReductionResponse] | List[ReductionWithRunsResponse]:
     """
     Retrieve a list of reductions for a given instrument.
     \f

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -45,6 +45,7 @@ async def get_pre_script(
 ) -> PreScriptResponse:
     """
     Script URI - Not intended for calling
+    \f
     :param instrument: the instrument
     :param background_tasks: handled by fastapi
     :param reduction_id: optional query parameter of runfile, used to apply transform
@@ -63,10 +64,12 @@ async def get_pre_script(
 @ROUTER.get("/instrument/{instrument}/script/sha/{sha}")
 async def get_pre_script_by_sha(instrument: str, sha: str, reduction_id: Optional[int] = None) -> PreScriptResponse:
     """
-
-    :param instrument:
-    :param sha:
-    :param reduction_id:
+    Given an instrument and the commit sha of a script, obtain the pre script. Optionally providing a reduction id to
+    transform the script
+    \f
+    :param instrument: The instrument
+    :param sha: The commit sha of the script
+    :param reduction_id: The reduction id to apply transforms
     :return:
     """
     return get_script_by_sha(instrument, sha, reduction_id).to_response()
@@ -82,6 +85,7 @@ async def get_reductions_for_instrument(
 ) -> List[ReductionResponse]:
     """
     Retrieve a list of reductions for a given instrument.
+    \f
     :param instrument: the name of the instrument
     :param limit: optional limit for the number of reductions returned (default is 0, which can be interpreted as
     no limit)
@@ -103,6 +107,7 @@ async def count_reductions_for_instrument(
 ) -> CountResponse:
     """
     Count reductions for a given instrument.
+    \f
     :param instrument: the name of the instrument
     :return: List of ReductionResponse objects
     """
@@ -114,6 +119,7 @@ async def count_reductions_for_instrument(
 async def get_reduction(reduction_id: int) -> ReductionWithRunsResponse:
     """
     Retrieve a reduction with nested run data, by iD.
+    \f
     :param reduction_id: the unique identifier of the reduction
     :return: ReductionWithRunsResponse object
     """
@@ -131,6 +137,7 @@ async def get_reductions_for_experiment(
 ) -> List[ReductionResponse]:
     """
     Retrieve a list of reductions associated with a specific experiment number.
+    \f
     :param experiment_number: the unique experiment number:
     :param limit: Number of results to limit to
     :param offset: Number of results to offset by
@@ -150,6 +157,7 @@ async def get_reductions_for_experiment(
 async def count_all_reductions() -> CountResponse:
     """
     Count all reductions
+    \f
     :return: CountResponse containing the count
     """
     return CountResponse(count=count_reductions())
@@ -159,6 +167,7 @@ async def count_all_reductions() -> CountResponse:
 async def count_all_runs() -> CountResponse:
     """
     Count all runs
+    \f
     :return: Count response containing the count
     """
     return CountResponse(count=get_total_run_count())
@@ -168,6 +177,7 @@ async def count_all_runs() -> CountResponse:
 async def count_runs_for_instrument(instrument: str) -> CountResponse:
     """
     Count the total runs for the given instrument
+    \f
     :param instrument: The instrument
     :return: The count response
     """
@@ -185,6 +195,7 @@ async def get_runs_for_instrument(
 ) -> List[RunResponse]:
     """
     Get all runs for the given instrument
+    \f
     :param instrument: The instrument
     :param limit: Optional limit to apply
     :param offset: Optional offset to apply

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -1,6 +1,8 @@
 """
 Module containing the REST endpoints
 """
+from __future__ import annotations
+
 from typing import Optional, List, Literal
 
 from fastapi import APIRouter

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -82,6 +82,7 @@ async def get_reductions_for_instrument(
     offset: int = 0,
     order_by: Literal["reduction_start", "reduction_end", "reduction_state", "id"] = "reduction_start",
     order_direction: Literal["asc", "desc"] = "desc",
+    include_runs: bool = False,
 ) -> List[ReductionResponse]:
     """
     Retrieve a list of reductions for a given instrument.
@@ -92,12 +93,15 @@ async def get_reductions_for_instrument(
     :param offset: optional offset for the list of reductions (default is 0)
     :param order_by: Literal["reduction_start", "reduction_end", "reduction_state", "id"]
     :param order_direction: Literal["asc", "desc"]
+    :param include_runs: bool
     :return: List of ReductionResponse objects
     """
     instrument = instrument.upper()
     reductions = get_reductions_by_instrument(
         instrument, limit=limit, offset=offset, order_by=order_by, order_direction=order_direction
     )
+    if include_runs:
+        return [ReductionWithRunsResponse.from_reduction(r) for r in reductions]
     return [ReductionResponse.from_reduction(r) for r in reductions]
 
 
@@ -190,7 +194,9 @@ async def get_runs_for_instrument(
     instrument: str,
     limit: int = 0,
     offset: int = 0,
-    order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
+    order_by: Literal[
+        "experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id", "filename"
+    ] = "run_start",
     order_direction: Literal["asc", "desc"] = "desc",
 ) -> List[RunResponse]:
     """

--- a/test/core/services/test_run.py
+++ b/test/core/services/test_run.py
@@ -1,0 +1,42 @@
+"""
+Tests for run service
+"""
+from typing import Callable
+from unittest.mock import patch
+
+from ir_api.core.services.run import get_runs_by_instrument, get_run_count_by_instrument, get_total_run_count
+
+
+@patch("ir_api.core.services.run._RUN_REPO")
+def test_get_runs_by_instrument(mock_run_repo):
+    """
+    Test that get_runs by instrument makes correct repo call
+    :param mock_run_repo: Mock repo
+    :return: None
+    """
+    get_runs_by_instrument("test", limit=5, offset=6)
+    assert mock_run_repo.find.call_count == 1
+    assert mock_run_repo.find.call_args[1]["limit"] == 5
+    assert mock_run_repo.find.call_args[1]["offset"] == 6
+
+
+@patch("ir_api.core.services.run._RUN_REPO")
+def test_get_run_count_by_instrument(mock_repo):
+    """
+    Test correct repo calls for count by instrument
+    :return: None
+    """
+    get_run_count_by_instrument("test")
+    assert mock_repo.count.call_count == 1
+    args, _ = mock_repo.count.call_args
+    assert isinstance(args[0], Callable)
+
+
+@patch("ir_api.core.services.run._RUN_REPO")
+def test_get_total_run_count(mock_repo):
+    """
+    Test correct repo calls for counting all runs
+    :return: None
+    """
+    get_total_run_count()
+    mock_repo.count.assert_called_once()

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -250,6 +250,23 @@ def test_instrument_reductions_count():
     assert response.json()["count"] == 1
 
 
+def test_instrument_runs_count():
+    """
+    Test instrument runs count
+    :return:
+    """
+    response = client.get("/instrument/TEST/runs/count")
+    assert response.json()["count"] == 1
+
+
+def test_total_runs_count():
+    """
+    Test total runs count
+    """
+    response = client.get("/runs/count")
+    assert response.json()["count"] == 5001
+
+
 def test_readiness_and_liveness_probes():
     """
     Test endpoint for probes

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -267,6 +267,27 @@ def test_total_runs_count():
     assert response.json()["count"] == 5001
 
 
+def test_get_runs_by_instrument():
+    """
+    Test getting runs by instrument
+    :return:
+    """
+    response = client.get("/instrument/TEST/runs")
+    assert len(response.json()) == 1
+    assert response.json()[0] == {
+        "experiment_number": 1820497,
+        "filename": "MAR25581.nxs",
+        "good_frames": 6452,
+        "instrument_name": "TEST",
+        "raw_frames": 8067,
+        "run_end": "2019-03-22T10:18:26",
+        "run_start": "2019-03-22T10:15:44",
+        "title": "Whitebeam - vanadium - detector tests - vacuum bad - HT on not on all LAB",
+        "users": "Wood,Guidi,Benedek,Mansson,Juranyi,Nocerino,Forslund,Matsubara",
+    }
+    assert response.status_code == 200
+
+
 def test_readiness_and_liveness_probes():
     """
     Test endpoint for probes

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -196,6 +196,47 @@ def test_get_reductions_for_instrument_reductions_exist():
     ]
 
 
+def test_get_reductions_for_instrument_runs_included():
+    """Test runs are included when requested for given instrument when instrument and reductions exist"""
+    response = client.get("/instrument/test/reductions?include_runs=true")
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": 5001,
+            "reduction_end": None,
+            "reduction_inputs": {
+                "ei": "'auto'",
+                "mask_file_link": "https://raw.githubusercontent.com/pace-neutrons/InstrumentFiles/964733aec28b00b13f32fb61afa363a74dd62130/mari/mari_mask2023_1.xml",
+                "monovan": 0,
+                "remove_bkg": True,
+                "runno": 25581,
+                "sam_mass": 0.0,
+                "sam_rmm": 0.0,
+                "sum_runs": False,
+                "wbvan": 12345,
+            },
+            "reduction_outputs": None,
+            "reduction_start": None,
+            "reduction_state": "NOT_STARTED",
+            "reduction_status_message": None,
+            "runs": [
+                {
+                    "experiment_number": 1820497,
+                    "filename": "MAR25581.nxs",
+                    "good_frames": 6452,
+                    "instrument_name": "TEST",
+                    "raw_frames": 8067,
+                    "run_end": "2019-03-22T10:18:26",
+                    "run_start": "2019-03-22T10:15:44",
+                    "title": "Whitebeam - vanadium - detector tests - vacuum bad - HT " "on not on all LAB",
+                    "users": "Wood,Guidi,Benedek,Mansson,Juranyi,Nocerino,Forslund,Matsubara",
+                }
+            ],
+            "script": None,
+        }
+    ]
+
+
 def test_reductions_by_instrument_no_reductions():
     """
     Test empty array returned when no reductions for instrument


### PR DESCRIPTION
closes #246
closes #252
This adds the new endpoints required for the frontend but does not tackle the optimisation issue. 
We can tackle the optimisation issue after if it is still necessary using the new endpoints. 
Also adds a query param to include runs when getting reductions by instrument


