### PR TITLE
Implement specification pattern with new endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,9 @@ def get_transform_for_instrument(instrument: str) -> Transform:
 ```
 
 ## Data Access Pattern
-The api is implementing a trimmed down version of the repository pattern. It is trimmed down in that, there is no data
-mapper pattern being used, and therefore the seperation of business and data layers is not complete as there is no
-separation of domain entities and database models. It also does not implement generalised search criteria and the api 
-depends directly on `LambdaElement` criteria.
-However, this trimmed down implementation does offer the other benefits of the pattern while reducing some of the 
-drawbacks. It provides a unified data access api, which significantly reduces complexity in querying data and testing
-while mocking data access. By being trimmed down, the increased complexity that can arise from the implementation of 
-model mappers/transformers is reduced.  
+The api is implementing a repository and specification pattern.
+All queries are defined within specifications, basic ordering is available in the base specification module via a func
+and a `@paginate` decorator is available to provide pagination to any specification.
 
 ## Database Generation Script for Development Environment
 ### Overview

--- a/ir_api/core/repositories.py
+++ b/ir_api/core/repositories.py
@@ -81,5 +81,8 @@ class Repo(Generic[T]):
         :return: The count of entities of type T that match the specification.
         """
         with self._session() as session:
-            result = session.execute(select(func.count()).select_from(spec.value))
-            return result.scalar() if result else 0
+            # pylint: disable = not-callable
+            # mypy does not like these, but they are valid.
+            result = session.execute(select(func.count()).select_from(spec.value))  # type: ignore
+            # pylint: enable = not-callable
+            return result.scalar() if result else 0  # type: ignore

--- a/ir_api/core/repositories.py
+++ b/ir_api/core/repositories.py
@@ -1,207 +1,91 @@
 """
-This module defines repository classes for handling data access operations on
-database tables mapped to SQLAlchemy ORM models for the `Script`, `Reduction`, `Run`,
-and `Instrument` entities.
+Provides a generic repository class for performing database operations.
 """
 import logging
 import os
-from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, Type, Optional, Callable, Sequence, Union, Literal
+from pprint import pprint
+from typing import Generic, TypeVar, Sequence, Optional
 
-from sqlalchemy import create_engine, select, LambdaElement, ColumnElement, NullPool
-from sqlalchemy.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy import select, func, create_engine, NullPool
+from sqlalchemy.exc import NoResultFound, MultipleResultsFound
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql.functions import func
 
 from ir_api.core.exceptions import NonUniqueRecordError
-from ir_api.core.model import Script, Reduction, Run, Instrument, Base
-
-logger = logging.getLogger(__name__)
+from ir_api.core.model import Base
+from ir_api.core.specifications.base import Specification
+from ir_api.core.specifications.run import RunSpecification
 
 T = TypeVar("T", bound=Base)
+
+logger = logging.getLogger(__name__)
 
 DB_USERNAME = os.environ.get("DB_USERNAME", "postgres")
 DB_PASSWORD = os.environ.get("DB_PASSWORD", "password")
 DB_IP = os.environ.get("DB_IP", "localhost")
+
 ENGINE = create_engine(
     f"postgresql+psycopg2://{DB_USERNAME}:{DB_PASSWORD}@{DB_IP}:5432/interactive-reduction",
     poolclass=NullPool,
-    echo=True,
 )
+
 SESSION = sessionmaker(ENGINE)
 
 
-class ReadOnlyRepo(ABC, Generic[T]):
+class Repo(Generic[T]):
     """
-    A generic read-only repository class for handling data access operations on
-    database tables mapped to SQLAlchemy ORM models.
+    A generic repository class for performing database operations on entities of type T.
 
-    This class should be subclassed and the `_model_type` property should be implemented
-    to provide the specific ORM model for the corresponding repository.
+    This class provides methods to find one or multiple entities based on a specification,
+    and to count entities matching a specification. It is designed to work with any entity
+    that inherits from the base model class.
     """
 
     def __init__(self) -> None:
         self._session = SESSION
 
-    @property
-    @abstractmethod
-    def _model_type(self) -> Type[T]:
-        pass
-
-    def find_one(
-        self, filter_expression: Callable[[Type[T]], Union[LambdaElement, ColumnElement["bool"]]]
-    ) -> Optional[T]:
+    def find(self, spec: Specification[T]) -> Sequence[T]:
         """
-        Find the single entity, if more than one is returned, a NonUniqueRecordError will be raised
+        Finds entities matching the given specification.
 
-        :param filter_expression: (Callable[[Type[T]], ColumnElement["bool"]]) The filter expression to be applied.
-        :return: (Optional[T]) The found entity, or None if not found.
+        :param spec: A specification defining the query criteria.
+        :return: A sequence of entities of type T that match the specification.
         """
-        logger.info(
-            "Finding one: %s",
-            self._model_type,
-        )
         with self._session() as session:
-            query = select(self._model_type)
-            query = query.filter(filter_expression(self._model_type))
-            try:
-                return session.execute(query).scalars().one()
-            except NoResultFound:
-                logger.info("No result found for %s", self._model_type)
-                return None
-            except MultipleResultsFound as exc:
-                logger.error("Non unique record found for filter: %s", filter_expression)
-                raise NonUniqueRecordError() from exc
-
-    def count(
-        self, filter_expression: Optional[Callable[[Type[T]], Union[LambdaElement, ColumnElement["bool"]]]] = None
-    ) -> int:
-        """
-        Count the existing entities, optionally matching a given filter expression
-        :param filter_expression: Optional filter expression
-        :return: The count
-        """
-        logger.info("Counting %s", self._model_type)
-        with self._session() as session:
-            # pylint: disable = not-callable
-            query = select(func.count()).select_from(self._model_type)
-            # pylint: enable = not-callable
-            query = query.filter(filter_expression(self._model_type)) if filter_expression else query
-            result = session.execute(query).scalars().first()
-            return result if result else 0
-
-    def find(
-        self,
-        filter_expression: Callable[[Type[T]], Union[LambdaElement, ColumnElement["bool"]]],
-        limit: int = 0,
-        offset: int = 0,
-        order_by: Optional[str] = None,
-        order_direction: Literal["asc", "desc"] = "asc",
-    ) -> Sequence[T]:
-        """
-        Find entities that match a specified filter expression.
-
-        :param filter_expression: (Callable[[Type[T]], ColumnElement["bool"]]) The filter expression to be applied.
-        :param limit: (int) The optional number to limit the sequence by
-        :param offset: (int) The optional number to offset the results by
-        :param order_by: (ColumnElement) Optional field to order by
-        :param order_direction: Literal["asc", "desc"] Optional order direction, defaults to ascending
-        :return: (Sequence[T]) A sequence of found entities.
-        """
-        logger.info("Finding %s", self._model_type)
-        with self._session() as session:
-            query = select(self._model_type)
-            query = query.filter(filter_expression(self._model_type))
-            if order_by:
-                column_element = getattr(self._model_type, order_by)
-                query = (
-                    query.order_by(column_element.asc())
-                    if order_direction == "asc"
-                    else query.order_by(column_element.desc())
-                )
-            if offset:
-                query = query.offset(offset)
-
-            if limit:
-                query = query.limit(limit)
-
+            query = spec.value
             return session.execute(query).scalars().all()
 
-
-class CRUDRepo(ReadOnlyRepo[T], ABC):
-    """
-    A generic repository class for handling CRUD operations (Create, Read, Update, Delete) on
-    database tables mapped to SQLAlchemy ORM models. Inherits from `ReadOnlyRepo`.
-
-    This class should be subclassed and the `_model_type`, `_entity_type`, and `_transformer`
-    properties should be implemented to provide the specific ORM model, domain entity, and
-    transformer for the corresponding repository.
-    """
-
-    def insert(self, entity: T) -> None:
+    def find_one(self, spec: Specification[T]) -> Optional[T]:
         """
-        Insert a new entity into the database.
+        Finds a single entity matching the given specification.
 
-        :param entity: (U) The entity to be inserted.
+        If no entities are found, None is returned. If multiple entities are found,
+        a NonUniqueRecordError is raised.
+
+        :param spec: A specification defining the query criteria.
+        :return: An entity of type T that matches the specification, or None if no entities are found.
+        :raises NonUniqueRecordError: If more than one entity matches the specification.
         """
-        # TODO: Phase 2
+        with self._session() as session:
+            try:
+                return session.execute(spec.value).scalars().one()
+            except NoResultFound:
+                logger.info("No result found for IMPROVE THIS LOGGING")
+                return None
+            except MultipleResultsFound as exc:
+                logger.error("Non unique record found for IMPROVE THIS LOGGING")
+                raise NonUniqueRecordError() from exc
 
-    def update(self, model: T) -> None:
+    def count(self, spec: Specification[T]) -> int:
         """
-        Update an existing entity in the database.
+        Counts the number of entities matching the given specification.
 
-        :param model: (U) The entity with updated values.
+        :param spec: A specification defining the query criteria.
+        :return: The count of entities of type T that match the specification.
         """
-        # TODO: Phase 2
-
-    def delete(self, entity: T) -> None:
-        """
-        Delete an existing entity from the database.
-
-        :param entity: (U) The entity to be deleted.
-        """
-        # TODO: Phase 2
+        with self._session() as session:
+            result = session.execute(select(func.count()).select_from(spec.value))
+            return result.scalar() if result else 0
 
 
-class ScriptRepo(ReadOnlyRepo[Script]):
-    """
-    A specific repository class for handling data access operations for the `Script` entity.
-    Inherits from `ReadOnlyRepo`.
-    """
-
-    @property
-    def _model_type(self) -> Type[Script]:
-        return Script
-
-
-class ReductionRepo(ReadOnlyRepo[Reduction]):
-    """
-    A specific repository class for handling data access operations for the `Reduction` entity.
-    Inherits from `ReadOnlyRepo`.
-    """
-
-    @property
-    def _model_type(self) -> Type[Reduction]:
-        return Reduction
-
-
-class RunRepo(ReadOnlyRepo[Run]):
-    """
-    A specific repository class for handling data access operations for the `Run` entity.
-    Inherits from `ReadOnlyRepo`.
-    """
-
-    @property
-    def _model_type(self) -> Type[Run]:
-        return Run
-
-
-class InstrumentRepo(ReadOnlyRepo[Instrument]):
-    """
-    A specific repository class for handling data access operations for the `Instrument` entity.
-    Inherits from `ReadOnlyRepo`.
-    """
-
-    @property
-    def _model_type(self) -> Type[Instrument]:
-        return Instrument
+repo = Repo()
+pprint(repo.find(RunSpecification().all(limit=10, order_by="id", order_direction="desc")))

--- a/ir_api/core/repositories.py
+++ b/ir_api/core/repositories.py
@@ -83,4 +83,3 @@ class Repo(Generic[T]):
         with self._session() as session:
             result = session.execute(select(func.count()).select_from(spec.value))
             return result.scalar() if result else 0
-

--- a/ir_api/core/repositories.py
+++ b/ir_api/core/repositories.py
@@ -68,10 +68,10 @@ class Repo(Generic[T]):
             try:
                 return session.execute(spec.value).scalars().one()
             except NoResultFound:
-                logger.info("No result found for IMPROVE THIS LOGGING")
+                logger.exception("No result found for %s", spec.value)
                 return None
             except MultipleResultsFound as exc:
-                logger.error("Non unique record found for IMPROVE THIS LOGGING")
+                logger.exception("Non unique record found for %s", spec.value)
                 raise NonUniqueRecordError() from exc
 
     def count(self, spec: Specification[T]) -> int:

--- a/ir_api/core/repositories.py
+++ b/ir_api/core/repositories.py
@@ -3,7 +3,6 @@ Provides a generic repository class for performing database operations.
 """
 import logging
 import os
-from pprint import pprint
 from typing import Generic, TypeVar, Sequence, Optional
 
 from sqlalchemy import select, func, create_engine, NullPool
@@ -13,7 +12,6 @@ from sqlalchemy.orm import sessionmaker
 from ir_api.core.exceptions import NonUniqueRecordError
 from ir_api.core.model import Base
 from ir_api.core.specifications.base import Specification
-from ir_api.core.specifications.run import RunSpecification
 
 T = TypeVar("T", bound=Base)
 
@@ -86,6 +84,3 @@ class Repo(Generic[T]):
             result = session.execute(select(func.count()).select_from(spec.value))
             return result.scalar() if result else 0
 
-
-repo = Repo()
-pprint(repo.find(RunSpecification().all(limit=10, order_by="id", order_direction="desc")))

--- a/ir_api/core/responses.py
+++ b/ir_api/core/responses.py
@@ -119,7 +119,6 @@ class ReductionWithRunsResponse(ReductionResponse):
         :return: The ReductionWithRunsResponse Object
         """
         script = ScriptResponse(value=reduction.script.script) if reduction.script else None
-
         return ReductionWithRunsResponse(
             reduction_start=reduction.reduction_start,
             reduction_end=reduction.reduction_end,

--- a/ir_api/core/services/reduction.py
+++ b/ir_api/core/services/reduction.py
@@ -8,7 +8,7 @@ from ir_api.core.model import Reduction
 from ir_api.core.repositories import Repo
 from ir_api.core.specifications.reduction import ReductionSpecification
 
-ORDER_LITERALS = Literal[
+OrderField = Literal[
     "reduction_start",
     "reduction_end",
     "reduction_state",
@@ -27,7 +27,7 @@ def get_reductions_by_instrument(
     instrument: str,
     limit: int = 0,
     offset: int = 0,
-    order_by: ORDER_LITERALS = "reduction_start",
+    order_by: OrderField = "reduction_start",
     order_direction: Literal["asc", "desc"] = "desc",
 ) -> Sequence[Reduction]:
     """

--- a/ir_api/core/services/reduction.py
+++ b/ir_api/core/services/reduction.py
@@ -15,9 +15,10 @@ OrderField = Literal[
     "id",
     "run_start",
     "run_end",
-    "output",
+    "reduction_outputs",
     "experiment_number",
     "experiment_title",
+    "filename",
 ]
 
 _REPO: Repo[Reduction] = Repo()

--- a/ir_api/core/services/run.py
+++ b/ir_api/core/services/run.py
@@ -30,7 +30,9 @@ def get_runs_by_instrument(
     instrument: str,
     limit: int = 0,
     offset: int = 0,
-    order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
+    order_by: Literal[
+        "experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id", "filename"
+    ] = "run_start",
     order_direction: Literal["asc", "desc"] = "desc",
 ) -> Sequence[Run]:
     """

--- a/ir_api/core/services/run.py
+++ b/ir_api/core/services/run.py
@@ -1,0 +1,51 @@
+"""
+Service Layer for runs
+"""
+from typing import Sequence, Literal
+
+from ir_api.core.model import Instrument, Run
+from ir_api.core.repositories import RunRepo
+
+_RUN_REPO = RunRepo()
+
+
+def get_total_run_count() -> int:
+    """
+    Get the total number of runs
+    :return: The number of runs
+    """
+    return _RUN_REPO.count()
+
+
+def get_run_count_by_instrument(instrument: str) -> int:
+    """
+    Get the total number of runs for the given instrument
+    :param instrument: The instrument
+    :return: The number of runs
+    """
+    return _RUN_REPO.count(lambda run: run.instrument.has(Instrument.instrument_name == instrument))
+
+
+def get_runs_by_instrument(
+    instrument: str,
+    limit: int = 0,
+    offset: int = 0,
+    order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
+    order_direction: Literal["asc", "desc"] = "desc",
+) -> Sequence[Run]:
+    """
+    Get the runs for the given instrument
+    :param instrument: Instrument name
+    :param limit: optional limit to be applied
+    :param offset: optional offset to be applied
+    :param order_by: optional field to order by
+    :param order_direction: optional direction to order by in
+    :return: The sequence of runs
+    """
+    return _RUN_REPO.find(
+        lambda run: run.instrument.has(Instrument.instrument_name == instrument),
+        limit=limit,
+        offset=offset,
+        order_by=order_by,
+        order_direction=order_direction,
+    )

--- a/ir_api/core/services/run.py
+++ b/ir_api/core/services/run.py
@@ -3,10 +3,11 @@ Service Layer for runs
 """
 from typing import Sequence, Literal
 
-from ir_api.core.model import Instrument, Run
-from ir_api.core.repositories import RunRepo
+from ir_api.core.model import Run
+from ir_api.core.repositories import Repo
+from ir_api.core.specifications.run import RunSpecification
 
-_RUN_REPO = RunRepo()
+_REPO: Repo[Run] = Repo()
 
 
 def get_total_run_count() -> int:
@@ -14,7 +15,7 @@ def get_total_run_count() -> int:
     Get the total number of runs
     :return: The number of runs
     """
-    return _RUN_REPO.count()
+    return _REPO.count(RunSpecification().all())
 
 
 def get_run_count_by_instrument(instrument: str) -> int:
@@ -23,7 +24,7 @@ def get_run_count_by_instrument(instrument: str) -> int:
     :param instrument: The instrument
     :return: The number of runs
     """
-    return _RUN_REPO.count(lambda run: run.instrument.has(Instrument.instrument_name == instrument))
+    return _REPO.count(RunSpecification().by_instrument(instrument))
 
 
 def get_runs_by_instrument(
@@ -44,10 +45,8 @@ def get_runs_by_instrument(
     :param order_direction: optional direction to order by in
     :return: The sequence of runs
     """
-    return _RUN_REPO.find(
-        lambda run: run.instrument.has(Instrument.instrument_name == instrument),
-        limit=limit,
-        offset=offset,
-        order_by=order_by,
-        order_direction=order_direction,
+    return _REPO.find(
+        RunSpecification().by_instrument(
+            instrument, limit=limit, offset=offset, order_by=order_by, order_direction=order_direction
+        )
     )

--- a/ir_api/core/specifications/base.py
+++ b/ir_api/core/specifications/base.py
@@ -1,0 +1,137 @@
+"""
+Base Specification Module
+
+Defines the abstract base class for creating query specifications.
+These specifications are designed to encapsulate the logic for querying the database,
+allowing for reusable and composable query objects. This approach aims to separate
+the concerns of how objects are retrieved from the database from the rest of the application logic.
+"""
+
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from functools import wraps
+from typing import TypeVar, Generic, Type, Literal, Tuple
+
+from sqlalchemy import select, Select
+
+from ir_api.core.model import Base
+
+T = TypeVar("T", bound=Base)
+
+
+def apply_pagination(spec_value: Select[Tuple[T]], limit: int, offset: int) -> Select[Tuple[T]]:
+    """
+    Given a Select of T, apply given limits and offsets
+    :param spec_value: The Select
+    :param limit: The limit
+    :param offset: The offset
+    :return: The select with limits and offsets applied
+    """
+    if limit:
+        spec_value = spec_value.limit(limit)
+    if offset:
+        spec_value = spec_value.offset(offset)
+    return spec_value
+
+
+def apply_ordering(
+    spec_value: Select[Tuple[T]],
+    model: Type[T],
+    order_by: str,
+    order_direction: str,
+) -> Select[Tuple[T]]:
+    """
+    Apply basic ordering to the specification value.
+    Note: This can only be called when there are no joins. Orders based on relations should be implemented in the
+    specification method directly
+    :param spec_value:
+    :param model:
+    :param order_by:
+    :param order_direction:
+    :return:
+    """
+    column_element = getattr(model, order_by)
+    spec_value = (
+        spec_value.order_by(column_element.asc())
+        if order_direction == "asc"
+        else spec_value.order_by(column_element.desc())
+    )
+    return spec_value
+
+
+def paginate(func):
+    """
+    This decorator allows any specification method to accept the args limit: int and offset: int
+    and will apply them to the specifications query automagically. This means that the limit and offset args
+    will appear to be unused in the specification method, but they are not.
+    :param func:  The specification Method
+    :return: Wrapped specification method with pagination
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        limit = kwargs.get("limit", 0)
+        offset = kwargs.get("offset", 0)
+        self.value = apply_pagination(self.value, limit, offset)
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+class Specification(Generic[T], ABC):
+    """
+    An abstract base class that defines a generic query specification for an ORM model.
+
+    This class is designed to be subclassed by specific query specification implementations
+    that define how to retrieve instances of ORM models based on various criteria.
+    """
+
+    @property
+    @abstractmethod
+    def model(self) -> Type[T]:
+        """
+        An abstract property that should be overridden to return the SQLAlchemy model class
+        that the specification is targeting.
+
+        This property enables the specification to construct queries dynamically based on the model class.
+
+        :return: The SQLAlchemy model class that this specification targets.
+        """
+
+    def all(
+        self,
+        limit: int = 0,
+        offset: int = 0,
+        order_by: str = "id",
+        order_direction: Literal["asc", "desc"] = "desc",
+    ) -> Specification[T]:
+        """
+        Initializes the specification with a query that selects all records of the model.
+
+        This method can be used to start a query specification that retrieves all instances
+        of the specified model from the database.
+
+        :return: An instance of the specification class with the query initialized to select all records.
+        """
+        self.value = select(self.model)
+        # We can't decorate this method like inherited ones, as there is not a clean way to inherit the decorator
+        # metaclass hacks
+        self.value = apply_pagination(self.value, limit, offset)
+        self.value = apply_ordering(self.value, self.model, order_by, order_direction)
+
+        return self
+
+    def by_id(self, id: int) -> Specification[T]:
+        """
+        Filters the query to select only the record with the specified primary key ID.
+
+        This method is a common specification that can be used to retrieve a single instance
+        of the model based on its primary key.
+
+        :param id: The primary key ID of the model instance to retrieve.
+        :return: An instance of the specification class with the query filtered by the specified ID.
+        """
+        self.value = select(self.model).where(self.model.id == id)
+        return self

--- a/ir_api/core/specifications/base.py
+++ b/ir_api/core/specifications/base.py
@@ -88,6 +88,9 @@ class Specification(Generic[T], ABC):
     that define how to retrieve instances of ORM models based on various criteria.
     """
 
+    def __init__(self):
+        self.value: Select[Tuple[T]] = select(self.model)
+
     @property
     @abstractmethod
     def model(self) -> Type[T]:
@@ -123,15 +126,15 @@ class Specification(Generic[T], ABC):
 
         return self
 
-    def by_id(self, id: int) -> Specification[T]:
+    def by_id(self, id_: int) -> Specification[T]:
         """
         Filters the query to select only the record with the specified primary key ID.
 
         This method is a common specification that can be used to retrieve a single instance
         of the model based on its primary key.
 
-        :param id: The primary key ID of the model instance to retrieve.
+        :param id_: The primary key ID of the model instance to retrieve.
         :return: An instance of the specification class with the query filtered by the specified ID.
         """
-        self.value = select(self.model).where(self.model.id == id)
+        self.value = select(self.model).where(self.model.id == id_)
         return self

--- a/ir_api/core/specifications/base.py
+++ b/ir_api/core/specifications/base.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import wraps
-from typing import TypeVar, Generic, Type, Literal, Tuple
+from typing import TypeVar, Generic, Type, Literal, Tuple, Callable, Any
 
 from sqlalchemy import select, Select
 
@@ -61,7 +61,7 @@ def apply_ordering(
     return spec_value
 
 
-def paginate(func):
+def paginate(func: Callable[..., Any]) -> Callable[..., Any]:
     """
     This decorator allows any specification method to accept the args limit: int and offset: int
     and will apply them to the specifications query automagically. This means that the limit and offset args
@@ -71,7 +71,7 @@ def paginate(func):
     """
 
     @wraps(func)
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: Specification[T], *args: Tuple[Any], **kwargs: int) -> Any:
         limit = kwargs.get("limit", 0)
         offset = kwargs.get("offset", 0)
         self.value = apply_pagination(self.value, limit, offset)
@@ -88,7 +88,7 @@ class Specification(Generic[T], ABC):
     that define how to retrieve instances of ORM models based on various criteria.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.value: Select[Tuple[T]] = select(self.model)
 
     @property

--- a/ir_api/core/specifications/reduction.py
+++ b/ir_api/core/specifications/reduction.py
@@ -1,0 +1,117 @@
+"""
+Module defining specifications for querying Reduction entities within the IR API.
+
+It includes the ReductionSpecification class, which facilitates the construction of complex queries
+for fetching Reduction entities based on various criteria such as instrument name, experiment number,
+and ordering preferences.
+"""
+from __future__ import annotations
+
+from typing import Type, Tuple, Optional, Literal
+
+from sqlalchemy import select, Select
+
+from ir_api.core.model import Reduction, Instrument, Run, run_reduction_junction_table
+from ir_api.core.specifications.base import Specification, paginate, apply_ordering
+
+ReductionOrderField = Literal["reduction_start", "reduction_end", "reduction_state", "id", "output"]
+RunOrderField = Literal["run_start", "run_end", "experiment_number", "experiment_title"]
+JointRunReductionOrderField = RunOrderField | ReductionOrderField
+
+
+class ReductionSpecification(Specification[Reduction]):
+    """
+    A specification class for constructing queries to fetch Reduction entities.
+
+    This class supports filtering and ordering of reductions based on attributes of both
+    the Reduction and Run entities, including support for joint attributes.
+    """
+
+    def __init__(self) -> None:
+        self.value: Select[Tuple[Reduction]] = select(Reduction)
+
+    @property
+    def model(self) -> Type[Reduction]:
+        return Reduction
+
+    @paginate
+    def by_instrument(
+        self,
+        instrument: str,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        order_by: JointRunReductionOrderField = "id",
+        order_direction: Literal["asc", "desc"] = "desc",
+    ) -> ReductionSpecification:
+        """
+        Filters reductions by the specified instrument and applies ordering, limit, and offset to the query.
+
+        :param instrument: The name of the instrument to filter reductions by.
+        :param limit: The maximum number of reductions to return. None indicates no limit.
+        :param offset: The number of reductions to skip before starting to return the results. None for no offset.
+        :param order_by: The attribute to order the reductions by. Can be attributes of Reduction or Run entities.
+        :param order_direction: The direction to order the reductions, either 'asc' for ascending or 'desc' for descending.
+        :return: An instance of ReductionSpecification with the applied filters and ordering.
+        """
+        self.value = (
+            self.value.join(run_reduction_junction_table)
+            .join(Run)
+            .join(Instrument)
+            .where(Instrument.instrument_name == instrument)
+        )
+
+        match order_by:
+            case "run_start":
+                self.value = (
+                    self.value.order_by(Run.run_start.desc())
+                    if order_direction == "desc"
+                    else self.value.order_by(Run.run_start.asc())
+                )
+            case "run_end":
+                self.value = (
+                    self.value.order_by(Run.run_end.desc())
+                    if order_direction == "desc"
+                    else self.value.order_by(Run.run_end.asc())
+                )
+            case "experiment_number":
+                self.value = (
+                    self.value.order_by(Run.experiment_number.desc())
+                    if order_direction == "desc"
+                    else self.value.order_by(Run.experiment_number.asc())
+                )
+            case "experiment_title":
+                self.value = (
+                    self.value.order_by(Run.title.desc())
+                    if order_direction == "desc"
+                    else self.value.order_by(Run.title.asc())
+                )
+            case _:
+                apply_ordering(self.value, self.model, order_by, order_direction)
+
+        return self
+
+    @paginate
+    def by_experiment_number(
+        self,
+        experiment_number: int,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        order_by: ReductionOrderField = "id",
+        order_direction: Literal["asc", "desc"] = "desc",
+    ) -> ReductionSpecification:
+        """
+        Filters reductions by the specified experiment number and applies ordering, limit, and offset to the query.
+
+        :param experiment_number: The experiment number to filter reductions by.
+        :param limit: The maximum number of reductions to return. None indicates no limit.
+        :param offset: The number of reductions to skip before starting to return the results. None for no offset.
+        :param order_by: The attribute of the Reduction entity to order the reductions by.
+        :param order_direction: The direction to order the reductions, either 'asc' for ascending or 'desc' for descending.
+        :return: An instance of ReductionSpecification with the applied filters and ordering.
+        """
+
+        self.value = (
+            self.value.join(run_reduction_junction_table).join(Run).where(Run.experiment_number == experiment_number)
+        )
+        apply_ordering(self.value, self.model, order_by, order_direction)
+        return self

--- a/ir_api/core/specifications/reduction.py
+++ b/ir_api/core/specifications/reduction.py
@@ -5,18 +5,19 @@ It includes the ReductionSpecification class, which facilitates the construction
 for fetching Reduction entities based on various criteria such as instrument name, experiment number,
 and ordering preferences.
 """
+# pylint: disable=unused-argument
+# The limit and offsets in specifications will incorrectly flag as unused. They are used when they are intercepted by
+# the paginate decorator
 from __future__ import annotations
 
-from typing import Type, Tuple, Optional, Literal
-
-from sqlalchemy import select, Select
+from typing import Type, Optional, Literal, Union
 
 from ir_api.core.model import Reduction, Instrument, Run, run_reduction_junction_table
 from ir_api.core.specifications.base import Specification, paginate, apply_ordering
 
 ReductionOrderField = Literal["reduction_start", "reduction_end", "reduction_state", "id", "output"]
 RunOrderField = Literal["run_start", "run_end", "experiment_number", "experiment_title"]
-JointRunReductionOrderField = RunOrderField | ReductionOrderField
+JointRunReductionOrderField = Union[RunOrderField, ReductionOrderField]
 
 
 class ReductionSpecification(Specification[Reduction]):
@@ -26,9 +27,6 @@ class ReductionSpecification(Specification[Reduction]):
     This class supports filtering and ordering of reductions based on attributes of both
     the Reduction and Run entities, including support for joint attributes.
     """
-
-    def __init__(self) -> None:
-        self.value: Select[Tuple[Reduction]] = select(Reduction)
 
     @property
     def model(self) -> Type[Reduction]:
@@ -50,7 +48,8 @@ class ReductionSpecification(Specification[Reduction]):
         :param limit: The maximum number of reductions to return. None indicates no limit.
         :param offset: The number of reductions to skip before starting to return the results. None for no offset.
         :param order_by: The attribute to order the reductions by. Can be attributes of Reduction or Run entities.
-        :param order_direction: The direction to order the reductions, either 'asc' for ascending or 'desc' for descending.
+        :param order_direction: The direction to order the reductions, either 'asc' for ascending or 'desc' for
+        descending.
         :return: An instance of ReductionSpecification with the applied filters and ordering.
         """
         self.value = (
@@ -106,7 +105,8 @@ class ReductionSpecification(Specification[Reduction]):
         :param limit: The maximum number of reductions to return. None indicates no limit.
         :param offset: The number of reductions to skip before starting to return the results. None for no offset.
         :param order_by: The attribute of the Reduction entity to order the reductions by.
-        :param order_direction: The direction to order the reductions, either 'asc' for ascending or 'desc' for descending.
+        :param order_direction: The direction to order the reductions, either 'asc' for ascending or 'desc' for
+        descending.
         :return: An instance of ReductionSpecification with the applied filters and ordering.
         """
 

--- a/ir_api/core/specifications/reduction.py
+++ b/ir_api/core/specifications/reduction.py
@@ -15,8 +15,8 @@ from typing import Type, Optional, Literal, Union
 from ir_api.core.model import Reduction, Instrument, Run, run_reduction_junction_table
 from ir_api.core.specifications.base import Specification, paginate, apply_ordering
 
-ReductionOrderField = Literal["reduction_start", "reduction_end", "reduction_state", "id", "output"]
-RunOrderField = Literal["run_start", "run_end", "experiment_number", "experiment_title"]
+ReductionOrderField = Literal["reduction_start", "reduction_end", "reduction_state", "id", "reduction_outputs"]
+RunOrderField = Literal["run_start", "run_end", "experiment_number", "experiment_title", "filename"]
 JointRunReductionOrderField = Union[RunOrderField, ReductionOrderField]
 
 
@@ -60,6 +60,12 @@ class ReductionSpecification(Specification[Reduction]):
         )
 
         match order_by:
+            case "filename":
+                self.value = (
+                    self.value.order_by(Run.filename.desc())
+                    if order_direction == "desc"
+                    else self.value.order_by(Run.filename.asc())
+                )
             case "run_start":
                 self.value = (
                     self.value.order_by(Run.run_start.desc())

--- a/ir_api/core/specifications/reduction.py
+++ b/ir_api/core/specifications/reduction.py
@@ -86,7 +86,7 @@ class ReductionSpecification(Specification[Reduction]):
                     else self.value.order_by(Run.title.asc())
                 )
             case _:
-                apply_ordering(self.value, self.model, order_by, order_direction)
+                self.value = apply_ordering(self.value, self.model, order_by, order_direction)
 
         return self
 

--- a/ir_api/core/specifications/run.py
+++ b/ir_api/core/specifications/run.py
@@ -1,0 +1,56 @@
+"""
+Module defining specifications for querying Run entities in the IR API.
+
+It includes the RunSpecification class which allows for building complex queries
+for Run entities based on various criteria such as instrument, limit, offset,
+order by, and order direction.
+"""
+from __future__ import annotations
+
+from typing import Type, Literal
+
+from sqlalchemy import select
+
+from ir_api.core.model import Run, Instrument
+from ir_api.core.specifications.base import Specification, paginate, apply_ordering
+
+
+class RunSpecification(Specification[Run]):
+    """
+    A specification class for building queries to fetch Run entities.
+
+    Allows for filtering and ordering runs based on different attributes such as
+    instrument name, experiment number, run start/end times, and more.
+    """
+
+    def __init__(self):
+        self.value = select(Run)
+
+    @property
+    def model(self) -> Type[Run]:
+        return Run
+
+    @paginate
+    def by_instrument(
+        self,
+        instrument: str,
+        limit: int = 0,
+        offset: int = 0,
+        order_by: Literal[
+            "experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id", "filename"
+        ] = "run_start",
+        order_direction: Literal["asc", "desc"] = "desc",
+    ) -> RunSpecification:
+        """
+        Filters runs by the specified instrument and applies ordering, limit, and offset to the query.
+
+        :param instrument: The name of the instrument to filter runs by.
+        :param limit: The maximum number of runs to return.
+        :param offset: The number of runs to skip before starting to return the results.
+        :param order_by: The attribute to order the runs by.
+        :param order_direction: The direction to order the runs, either 'asc' for ascending or 'desc' for descending.
+        :return: An instance of RunSpecification with the applied filters and ordering.
+        """
+        self.value = self.value.join(Instrument).where(Instrument.instrument_name == instrument)
+        apply_ordering(self.value, self.model, order_by, order_direction)
+        return self

--- a/ir_api/core/specifications/run.py
+++ b/ir_api/core/specifications/run.py
@@ -5,11 +5,12 @@ It includes the RunSpecification class which allows for building complex queries
 for Run entities based on various criteria such as instrument, limit, offset,
 order by, and order direction.
 """
+# pylint: disable=unused-argument
+# The limit and offsets in specifications will incorrectly flag as unused. They are used when they are intercepted by
+# the paginate decorator
 from __future__ import annotations
 
 from typing import Type, Literal
-
-from sqlalchemy import select
 
 from ir_api.core.model import Run, Instrument
 from ir_api.core.specifications.base import Specification, paginate, apply_ordering
@@ -22,9 +23,6 @@ class RunSpecification(Specification[Run]):
     Allows for filtering and ordering runs based on different attributes such as
     instrument name, experiment number, run start/end times, and more.
     """
-
-    def __init__(self):
-        self.value = select(Run)
 
     @property
     def model(self) -> Type[Run]:

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -77,12 +77,25 @@ async def get_pre_script_by_sha(instrument: str, sha: str, reduction_id: Optiona
     return get_script_by_sha(instrument, sha, reduction_id).to_response()
 
 
+ORDER_LITERALS = Literal[
+    "reduction_start",
+    "reduction_end",
+    "reduction_state",
+    "id",
+    "run_start",
+    "run_end",
+    "output",
+    "experiment_number",
+    "experiment_title",
+]
+
+
 @ROUTER.get("/instrument/{instrument}/reductions")
 async def get_reductions_for_instrument(
     instrument: str,
     limit: int = 0,
     offset: int = 0,
-    order_by: Literal["reduction_start", "reduction_end", "reduction_state", "id"] = "reduction_start",
+    order_by: ORDER_LITERALS = "reduction_start",
     order_direction: Literal["asc", "desc"] = "desc",
     include_runs: bool = False,
 ) -> List[ReductionResponse] | List[ReductionWithRunsResponse]:

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -84,9 +84,10 @@ OrderField = Literal[
     "id",
     "run_start",
     "run_end",
-    "output",
+    "reduction_outputs",
     "experiment_number",
     "experiment_title",
+    "filename",
 ]
 
 

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -11,6 +11,7 @@ from ir_api.core.responses import (
     ReductionResponse,
     ReductionWithRunsResponse,
     CountResponse,
+    RunResponse,
 )
 from ir_api.core.services.reduction import (
     get_reductions_by_instrument,
@@ -19,6 +20,7 @@ from ir_api.core.services.reduction import (
     count_reductions,
     count_reductions_by_instrument,
 )
+from ir_api.core.services.run import get_total_run_count, get_run_count_by_instrument, get_runs_by_instrument
 from ir_api.scripts.acquisition import (
     get_script_for_reduction,
     write_script_locally,
@@ -151,3 +153,39 @@ async def count_all_reductions() -> CountResponse:
     :return: CountResponse containing the count
     """
     return CountResponse(count=count_reductions())
+
+
+@ROUTER.get("/runs/count")
+async def count_all_runs() -> CountResponse:
+    """
+    Count all runs
+    :return: Count response containing the count
+    """
+    return CountResponse(count=get_total_run_count())
+
+
+@ROUTER.get("/instrument/{instrument}/runs/count")
+async def count_runs_for_instrument(instrument: str) -> CountResponse:
+    """
+    Count the total runs for the given instrument
+    :param instrument: The instrument
+    :return: The count response
+    """
+    instrument = instrument.upper()
+    return CountResponse(count=get_run_count_by_instrument(instrument))
+
+
+@ROUTER.get("/instrument/{instrument}/runs")
+async def get_runs_for_instrument(
+    instrument: str,
+    limit: int = 0,
+    offset: int = 0,
+    order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
+    order_direction: Literal["asc", "desc"] = "desc",
+) -> List[RunResponse]:
+    return [
+        RunResponse.from_run(run)
+        for run in get_runs_by_instrument(
+            instrument.upper(), limit=limit, offset=offset, order_by=order_by, order_direction=order_direction
+        )
+    ]

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -183,6 +183,15 @@ async def get_runs_for_instrument(
     order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
     order_direction: Literal["asc", "desc"] = "desc",
 ) -> List[RunResponse]:
+    """
+    Get all runs for the given instrument
+    :param instrument: The instrument
+    :param limit: Optional limit to apply
+    :param offset: Optional offset to apply
+    :param order_by: Optional field to order by
+    :param order_direction: Optional direction to order by
+    :return: List of RunResponses
+    """
     return [
         RunResponse.from_run(run)
         for run in get_runs_by_instrument(

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -77,7 +77,7 @@ async def get_pre_script_by_sha(instrument: str, sha: str, reduction_id: Optiona
     return get_script_by_sha(instrument, sha, reduction_id).to_response()
 
 
-ORDER_LITERALS = Literal[
+OrderField = Literal[
     "reduction_start",
     "reduction_end",
     "reduction_state",
@@ -95,7 +95,7 @@ async def get_reductions_for_instrument(
     instrument: str,
     limit: int = 0,
     offset: int = 0,
-    order_by: ORDER_LITERALS = "reduction_start",
+    order_by: OrderField = "reduction_start",
     order_direction: Literal["asc", "desc"] = "desc",
     include_runs: bool = False,
 ) -> List[ReductionResponse] | List[ReductionWithRunsResponse]:

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -83,7 +83,7 @@ async def get_reductions_for_instrument(
     order_by: Literal["reduction_start", "reduction_end", "reduction_state", "id"] = "reduction_start",
     order_direction: Literal["asc", "desc"] = "desc",
     include_runs: bool = False,
-) -> List[ReductionResponse]:
+) -> List[ReductionResponse] | List[ReductionWithRunsResponse]:
     """
     Retrieve a list of reductions for a given instrument.
     \f

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -45,6 +45,7 @@ async def get_pre_script(
 ) -> PreScriptResponse:
     """
     Script URI - Not intended for calling
+    \f
     :param instrument: the instrument
     :param background_tasks: handled by fastapi
     :param reduction_id: optional query parameter of runfile, used to apply transform
@@ -63,10 +64,12 @@ async def get_pre_script(
 @ROUTER.get("/instrument/{instrument}/script/sha/{sha}")
 async def get_pre_script_by_sha(instrument: str, sha: str, reduction_id: Optional[int] = None) -> PreScriptResponse:
     """
-
-    :param instrument:
-    :param sha:
-    :param reduction_id:
+    Given an instrument and the commit sha of a script, obtain the pre script. Optionally providing a reduction id to
+    transform the script
+    \f
+    :param instrument: The instrument
+    :param sha: The commit sha of the script
+    :param reduction_id: The reduction id to apply transforms
     :return:
     """
     return get_script_by_sha(instrument, sha, reduction_id).to_response()
@@ -82,6 +85,7 @@ async def get_reductions_for_instrument(
 ) -> List[ReductionResponse]:
     """
     Retrieve a list of reductions for a given instrument.
+    \f
     :param instrument: the name of the instrument
     :param limit: optional limit for the number of reductions returned (default is 0, which can be interpreted as
     no limit)
@@ -103,6 +107,7 @@ async def count_reductions_for_instrument(
 ) -> CountResponse:
     """
     Count reductions for a given instrument.
+    \f
     :param instrument: the name of the instrument
     :return: List of ReductionResponse objects
     """
@@ -114,6 +119,7 @@ async def count_reductions_for_instrument(
 async def get_reduction(reduction_id: int) -> ReductionWithRunsResponse:
     """
     Retrieve a reduction with nested run data, by iD.
+    \f
     :param reduction_id: the unique identifier of the reduction
     :return: ReductionWithRunsResponse object
     """
@@ -131,6 +137,7 @@ async def get_reductions_for_experiment(
 ) -> List[ReductionResponse]:
     """
     Retrieve a list of reductions associated with a specific experiment number.
+    \f
     :param experiment_number: the unique experiment number:
     :param limit: Number of results to limit to
     :param offset: Number of results to offset by
@@ -150,6 +157,7 @@ async def get_reductions_for_experiment(
 async def count_all_reductions() -> CountResponse:
     """
     Count all reductions
+    \f
     :return: CountResponse containing the count
     """
     return CountResponse(count=count_reductions())
@@ -159,6 +167,7 @@ async def count_all_reductions() -> CountResponse:
 async def count_all_runs() -> CountResponse:
     """
     Count all runs
+    \f
     :return: Count response containing the count
     """
     return CountResponse(count=get_total_run_count())
@@ -168,6 +177,7 @@ async def count_all_runs() -> CountResponse:
 async def count_runs_for_instrument(instrument: str) -> CountResponse:
     """
     Count the total runs for the given instrument
+    \f
     :param instrument: The instrument
     :return: The count response
     """
@@ -185,6 +195,7 @@ async def get_runs_for_instrument(
 ) -> List[RunResponse]:
     """
     Get all runs for the given instrument
+    \f
     :param instrument: The instrument
     :param limit: Optional limit to apply
     :param offset: Optional offset to apply

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -1,6 +1,8 @@
 """
 Module containing the REST endpoints
 """
+from __future__ import annotations
+
 from typing import Optional, List, Literal
 
 from fastapi import APIRouter

--- a/ir_api/router.py
+++ b/ir_api/router.py
@@ -82,6 +82,7 @@ async def get_reductions_for_instrument(
     offset: int = 0,
     order_by: Literal["reduction_start", "reduction_end", "reduction_state", "id"] = "reduction_start",
     order_direction: Literal["asc", "desc"] = "desc",
+    include_runs: bool = False,
 ) -> List[ReductionResponse]:
     """
     Retrieve a list of reductions for a given instrument.
@@ -92,12 +93,15 @@ async def get_reductions_for_instrument(
     :param offset: optional offset for the list of reductions (default is 0)
     :param order_by: Literal["reduction_start", "reduction_end", "reduction_state", "id"]
     :param order_direction: Literal["asc", "desc"]
+    :param include_runs: bool
     :return: List of ReductionResponse objects
     """
     instrument = instrument.upper()
     reductions = get_reductions_by_instrument(
         instrument, limit=limit, offset=offset, order_by=order_by, order_direction=order_direction
     )
+    if include_runs:
+        return [ReductionWithRunsResponse.from_reduction(r) for r in reductions]
     return [ReductionResponse.from_reduction(r) for r in reductions]
 
 
@@ -190,7 +194,9 @@ async def get_runs_for_instrument(
     instrument: str,
     limit: int = 0,
     offset: int = 0,
-    order_by: Literal["experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id"] = "run_start",
+    order_by: Literal[
+        "experiment_number", "run_end", "run_start", "good_frames", "raw_frames", "id", "filename"
+    ] = "run_start",
     order_direction: Literal["asc", "desc"] = "desc",
 ) -> List[RunResponse]:
     """

--- a/ir_api/scripts/acquisition.py
+++ b/ir_api/scripts/acquisition.py
@@ -8,7 +8,9 @@ from typing import Optional
 import requests
 
 from ir_api.core.exceptions import MissingRecordError, MissingScriptError
-from ir_api.core.repositories import ReductionRepo
+from ir_api.core.model import Reduction
+from ir_api.core.repositories import Repo
+from ir_api.core.specifications.reduction import ReductionSpecification
 from ir_api.core.utility import forbid_path_characters
 from ir_api.scripts.pre_script import PreScript
 from ir_api.scripts.transforms.factory import get_transform_for_instrument
@@ -135,9 +137,9 @@ def _transform_script(instrument: str, reduction_id: int, script: PreScript) -> 
     :param script: The Pre script
     :return: None
     """
-    reduction_repo = ReductionRepo()
+    reduction_repo: Repo[Reduction] = Repo()
     logger.info("Querying for reduction: %s", reduction_id)
-    reduction = reduction_repo.find_one(lambda r: r.id == reduction_id)
+    reduction = reduction_repo.find_one(ReductionSpecification().by_id(reduction_id))
     if not reduction:
         logger.info("Reduction not found")
         raise MissingRecordError(f"No reduction found with id: {reduction_id}")

--- a/test/core/services/test_reduction.py
+++ b/test/core/services/test_reduction.py
@@ -1,7 +1,6 @@
 """
 Tests for reduction service
 """
-from typing import Callable
 from unittest.mock import patch, Mock
 
 import pytest
@@ -16,21 +15,21 @@ from ir_api.core.services.reduction import (
 )
 
 
-@patch("ir_api.core.services.reduction._REDUCTION_REPO")
-def test_get_reductions_by_instrument(mock_repo):
+@patch("ir_api.core.services.reduction._REPO")
+@patch("ir_api.core.services.reduction.ReductionSpecification")
+def test_get_reductions_by_instrument(mock_spec_class, mock_repo):
     """
     Test that get_reductions by instrument makes correct repo call
     :param mock_repo: Mocked Repo class
     :return: None
     """
+    spec = mock_spec_class.return_value
     get_reductions_by_instrument("test", limit=5, offset=6)
 
-    assert mock_repo.find.call_count == 1
-    assert mock_repo.find.call_args[1]["limit"] == 5
-    assert mock_repo.find.call_args[1]["offset"] == 6
+    mock_repo.find.assert_called_once_with(spec.by_instrument("test", limit=5, offset=6))
 
 
-@patch("ir_api.core.services.reduction._REDUCTION_REPO")
+@patch("ir_api.core.services.reduction._REPO")
 def test_get_reduction_by_id_reduction_exists(mock_repo):
     """
     Test that correct repo call and return is made
@@ -43,7 +42,7 @@ def test_get_reduction_by_id_reduction_exists(mock_repo):
     assert reduction == expected_reduction
 
 
-@patch("ir_api.core.services.reduction._REDUCTION_REPO")
+@patch("ir_api.core.services.reduction._REPO")
 def test_get_reduction_by_id_not_found_raises(mock_repo):
     """
     Test MissingRecordError raised when repo returns None
@@ -55,21 +54,21 @@ def test_get_reduction_by_id_not_found_raises(mock_repo):
         get_reduction_by_id(1)
 
 
-@patch("ir_api.core.services.reduction._REDUCTION_REPO")
-def test_get_reductions_by_experiment_number(mock_repo):
+@patch("ir_api.core.services.reduction._REPO")
+@patch("ir_api.core.services.reduction.ReductionSpecification")
+def test_get_reductions_by_experiment_number(mock_spec_class, mock_repo):
     """
     Test correct Repo calls are made for by experiment number
     :param mock_repo: The Mocked Repo
     :return: None
     """
+    spec = mock_spec_class.return_value
     get_reductions_by_experiment_number(123456, limit=6, offset=7)
 
-    assert mock_repo.find.call_count == 1
-    assert mock_repo.find.call_args[1]["limit"] == 6
-    assert mock_repo.find.call_args[1]["offset"] == 7
+    mock_repo.find.assert_called_once_with(spec.by_experiment_number(experiment_number=123456, limit=6, offset=7))
 
 
-@patch("ir_api.core.services.reduction._REDUCTION_REPO")
+@patch("ir_api.core.services.reduction._REPO")
 def test_count_reductions(mock_repo):
     """
     Test count is called
@@ -79,14 +78,14 @@ def test_count_reductions(mock_repo):
     mock_repo.count.assert_called_once()
 
 
-@patch("ir_api.core.services.reduction._REDUCTION_REPO")
-def test_count_reductions_by_instrument(mock_repo):
+@patch("ir_api.core.services.reduction._REPO")
+@patch("ir_api.core.services.reduction.ReductionSpecification")
+def test_count_reductions_by_instrument(mock_spec_class, mock_repo):
     """
     Test count by instrument
     :param mock_repo: mock repo fixture
     :return: None
     """
+    spec = mock_spec_class.return_value
     count_reductions_by_instrument("TEST")
-    assert mock_repo.count.call_count == 1
-    args, _ = mock_repo.count.call_args
-    assert isinstance(args[0], Callable)
+    mock_repo.count.assert_called_once_with(spec.by_instrument("TEST"))

--- a/test/core/services/test_run.py
+++ b/test/core/services/test_run.py
@@ -1,0 +1,42 @@
+"""
+Tests for run service
+"""
+from typing import Callable
+from unittest.mock import patch
+
+from ir_api.core.services.run import get_runs_by_instrument, get_run_count_by_instrument, get_total_run_count
+
+
+@patch("ir_api.core.services.run._RUN_REPO")
+def test_get_runs_by_instrument(mock_run_repo):
+    """
+    Test that get_runs by instrument makes correct repo call
+    :param mock_run_repo: Mock repo
+    :return: None
+    """
+    get_runs_by_instrument("test", limit=5, offset=6)
+    assert mock_run_repo.find.call_count == 1
+    assert mock_run_repo.find.call_args[1]["limit"] == 5
+    assert mock_run_repo.find.call_args[1]["offset"] == 6
+
+
+@patch("ir_api.core.services.run._RUN_REPO")
+def test_get_run_count_by_instrument(mock_repo):
+    """
+    Test correct repo calls for count by instrument
+    :return: None
+    """
+    get_run_count_by_instrument("test")
+    assert mock_repo.count.call_count == 1
+    args, _ = mock_repo.count.call_args
+    assert isinstance(args[0], Callable)
+
+
+@patch("ir_api.core.services.run._RUN_REPO")
+def test_get_total_run_count(mock_repo):
+    """
+    Test correct repo calls for counting all runs
+    :return: None
+    """
+    get_total_run_count()
+    mock_repo.count.assert_called_once()

--- a/test/core/services/test_run.py
+++ b/test/core/services/test_run.py
@@ -1,42 +1,43 @@
 """
 Tests for run service
 """
-from typing import Callable
 from unittest.mock import patch
 
 from ir_api.core.services.run import get_runs_by_instrument, get_run_count_by_instrument, get_total_run_count
 
 
-@patch("ir_api.core.services.run._RUN_REPO")
-def test_get_runs_by_instrument(mock_run_repo):
+@patch("ir_api.core.services.run._REPO")
+@patch("ir_api.core.services.run.RunSpecification")
+def test_get_runs_by_instrument(mock_spec_class, mock_run_repo):
     """
     Test that get_runs by instrument makes correct repo call
     :param mock_run_repo: Mock repo
     :return: None
     """
+    spec = mock_spec_class.return_value
     get_runs_by_instrument("test", limit=5, offset=6)
-    assert mock_run_repo.find.call_count == 1
-    assert mock_run_repo.find.call_args[1]["limit"] == 5
-    assert mock_run_repo.find.call_args[1]["offset"] == 6
+    mock_run_repo.find.assert_called_once_with(spec.by_instrument(instrument="test", limit=5, offset=6))
 
 
-@patch("ir_api.core.services.run._RUN_REPO")
-def test_get_run_count_by_instrument(mock_repo):
+@patch("ir_api.core.services.run._REPO")
+@patch("ir_api.core.services.run.RunSpecification")
+def test_get_run_count_by_instrument(mock_spec_class, mock_repo):
     """
     Test correct repo calls for count by instrument
     :return: None
     """
+    spec = mock_spec_class.return_value
     get_run_count_by_instrument("test")
-    assert mock_repo.count.call_count == 1
-    args, _ = mock_repo.count.call_args
-    assert isinstance(args[0], Callable)
+    mock_repo.count.assert_called_once_with(spec.by_instrument(instrument="test", limit=5, offset=6))
 
 
-@patch("ir_api.core.services.run._RUN_REPO")
-def test_get_total_run_count(mock_repo):
+@patch("ir_api.core.services.run._REPO")
+@patch("ir_api.core.services.run.RunSpecification")
+def test_get_total_run_count(mock_spec_class, mock_repo):
     """
     Test correct repo calls for counting all runs
     :return: None
     """
+    spec = mock_spec_class.return_value
     get_total_run_count()
-    mock_repo.count.assert_called_once()
+    mock_repo.count.assert_called_once_with(spec.all())

--- a/test/core/test_repositories_integration.py
+++ b/test/core/test_repositories_integration.py
@@ -1,25 +1,40 @@
 """
 Inegration tests for data access.
 Requires postgres running with user postgres and password password
+Tests designed to test every specification with it's respective repo
+with a live db connection
 """
-from datetime import datetime
+import datetime
 
 import pytest
 
 from ir_api.core.exceptions import NonUniqueRecordError
 from ir_api.core.model import Base, Script, Instrument, Reduction, ReductionState, Run
-from ir_api.core.repositories import ScriptRepo, ENGINE, SESSION, ReductionRepo, RunRepo, InstrumentRepo
+from ir_api.core.repositories import ENGINE, SESSION, Repo
+from ir_api.core.specifications.reduction import ReductionSpecification
+from ir_api.core.specifications.run import RunSpecification
 
 # pylint: disable = redefined-outer-name
 
 TEST_SCRIPT = Script(script="print('Script 1')")
 TEST_REDUCTION = Reduction(
-    reduction_start=datetime.utcnow(),
+    reduction_start=datetime.datetime.now(datetime.UTC),
     reduction_state=ReductionState.NOT_STARTED,
     reduction_inputs={"input": "value"},
     script=TEST_SCRIPT,
 )
-
+TEST_REDUCTION_2 = Reduction(
+    reduction_start=datetime.datetime.now(datetime.UTC),
+    reduction_state=ReductionState.UNSUCCESSFUL,
+    reduction_inputs={"input": "value"},
+    script=TEST_SCRIPT,
+)
+TEST_REDUCTION_3 = Reduction(
+    reduction_start=datetime.datetime.now(datetime.UTC),
+    reduction_state=ReductionState.SUCCESSFUL,
+    reduction_inputs={"input": "value"},
+    script=TEST_SCRIPT,
+)
 TEST_INSTRUMENT_1 = Instrument(instrument_name="instrument 1")
 TEST_INSTRUMENT_2 = Instrument(instrument_name="instrument 2")
 
@@ -28,34 +43,43 @@ TEST_RUN_1 = Run(
     experiment_number=1,
     title="Test Run",
     users="User1, User2",
-    run_start=datetime.utcnow(),
-    run_end=datetime.utcnow(),
-    good_frames=100,
+    run_start=datetime.datetime.now(datetime.UTC),
+    run_end=datetime.datetime.now(datetime.UTC),
+    good_frames=200,
     raw_frames=200,
     instrument=TEST_INSTRUMENT_1,
 )
+TEST_RUN_1.reductions.append(TEST_REDUCTION_2)
 TEST_RUN_2 = Run(
     filename="test_run",
     experiment_number=2,
     title="Test Run 2",
     users="User1, User2",
-    run_start=datetime.utcnow(),
-    run_end=datetime.utcnow(),
+    run_start=datetime.datetime.now(datetime.UTC),
+    run_end=datetime.datetime.now(datetime.UTC),
     good_frames=100,
     raw_frames=200,
     instrument=TEST_INSTRUMENT_1,
 )
+TEST_RUN_2.reductions.append(TEST_REDUCTION)
 TEST_RUN_3 = Run(
     filename="test_run",
-    experiment_number=2,
+    experiment_number=3,
     title="Test Run 3",
     users="User1, User2",
-    run_start=datetime.utcnow(),
-    run_end=datetime.utcnow(),
+    run_start=datetime.datetime.now(datetime.UTC),
+    run_end=datetime.datetime.now(datetime.UTC),
     good_frames=100,
     raw_frames=200,
     instrument=TEST_INSTRUMENT_2,
 )
+TEST_REDUCTION_4 = Reduction(
+    reduction_start=datetime.datetime.now(datetime.UTC),
+    reduction_state=ReductionState.NOT_STARTED,
+    reduction_inputs={"input": "value"},
+    script=TEST_SCRIPT,
+)
+TEST_RUN_3.reductions.append(TEST_REDUCTION_4)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -66,7 +90,6 @@ def setup() -> None:
     """
     Base.metadata.drop_all(ENGINE)
     Base.metadata.create_all(ENGINE)
-    TEST_RUN_1.reductions.append(TEST_REDUCTION)
 
     with SESSION() as session:
         session.add(TEST_SCRIPT)
@@ -75,7 +98,6 @@ def setup() -> None:
         session.add(TEST_RUN_1)
         session.add(TEST_RUN_2)
         session.add(TEST_RUN_3)
-        session.add(TEST_REDUCTION)
         session.commit()
         session.refresh(TEST_SCRIPT)
         session.refresh(TEST_INSTRUMENT_1)
@@ -83,255 +105,93 @@ def setup() -> None:
         session.refresh(TEST_RUN_1)
         session.refresh(TEST_RUN_2)
         session.refresh(TEST_RUN_3)
-        session.refresh(TEST_REDUCTION)
 
     yield
 
 
 @pytest.fixture()
-def script_repo() -> ScriptRepo:
-    """
-    ScriptRepo fixture
-    :return: ScriptRepo
-    """
-    return ScriptRepo()
-
-
-@pytest.fixture()
-def reduction_repo() -> ReductionRepo:
+def reduction_repo() -> Repo[Reduction]:
     """
     ReductionRepo fixture
     :return: ReductionRepo
     """
-    return ReductionRepo()
+    return Repo()
 
 
 @pytest.fixture()
-def run_repo() -> RunRepo:
+def run_repo() -> Repo[Run]:
     """
     RunRepo fixture
     :return: RunRepo
     """
-    return RunRepo()
+    return Repo()
 
 
-@pytest.fixture()
-def instrument_repo() -> InstrumentRepo:
-    """
-    InstrumentRepo fixture
-    :return: InstrumentRepo
-    """
-    return InstrumentRepo()
+def test_base_spec_all(run_repo):
+    """Test all are in result"""
+    result = run_repo.find(RunSpecification().all())
+    assert TEST_RUN_3 in result
+    assert TEST_RUN_2 in result
+    assert TEST_RUN_1 in result
 
 
-def test_script_repo_find_one(script_repo):
-    """
-    Test find_one for script repo
-    :param script_repo: script repo fixture
-    :return: None
-    """
-    found_script = script_repo.find_one(lambda s: s.id == 1)
-    assert found_script == TEST_SCRIPT
+def test_base_spec_by_id(run_repo):
+    """Test find by id"""
+    result = run_repo.find_one(RunSpecification().by_id(1))
+    assert result == TEST_RUN_1
 
 
-def test_reduction_repo_find_one(reduction_repo):
-    """
-    Test find_one for reduction repo
-    :param reduction_repo: reduction repo fixture
-    :return: None
-    """
-    found_reduction = reduction_repo.find_one(lambda r: r.id == 1)
-    assert found_reduction == TEST_REDUCTION
+def test_run_by_instrument(run_repo):
+    """Test finding runs by instrument"""
+    result = run_repo.find(RunSpecification().by_instrument("instrument 1"))
+    assert result == [TEST_RUN_1, TEST_RUN_2]
+    result = run_repo.find(
+        RunSpecification().by_instrument(
+            "instrument 1", limit=1, offset=1, order_by="good_frames", order_direction="desc"
+        )
+    )
+    assert result == [TEST_RUN_2]
 
 
-def test_run_repo_find_one(run_repo):
-    """
-    Test find_one for run repo
-    :param run_repo: run repo fixture
-    :return: None
-    """
-    found_run = run_repo.find_one(lambda r: r.id == 1)
-    assert found_run == TEST_RUN_1
-
-    # Test relationship between Run and Reduction
-    assert len(found_run.reductions) == 1
-    assert found_run.reductions[0] == TEST_REDUCTION
-
-
-def test_instrument_repo_find_one_none_exist_returns_none(instrument_repo):
-    """
-    Test none is returned when nothing is found from a find_one call
-    :param instrument_repo: InstrumentRepo fixture
-    :return: None
-    """
-    assert instrument_repo.find_one(lambda i: i.instrument_name == "baz") is None
-
-
-def test_run_repo_find_one_multiple_returned_raises_error(run_repo):
-    """
-    Test a multiple record exception will be raised if more than one result will be found
-    :param run_repo: run repo fixture
-    :return: none
-    """
+def test_run_by_instrument_raises_when_non_unique(run_repo):
+    """Test correct exception raised when multiple runs exist"""
     with pytest.raises(NonUniqueRecordError):
-        run_repo.find_one(lambda r: r.users == "User1, User2")
+        run_repo.find_one(RunSpecification().by_instrument("instrument 1"))
 
 
-def test_instrument_repo_find_one(instrument_repo, run_repo):
-    """
-    Test find one returns one for instrument repo
-    :param instrument_repo: instrument repo fixture
-    :param run_repo: None
-    :return:
-    """
-    found_instrument = instrument_repo.find_one(lambda i: i.id == 1)
-    assert found_instrument == TEST_INSTRUMENT_1
-
-    # Test relationship between Run and Instrument
-    found_run = run_repo.find_one(lambda r: r.id == 1)
-    assert found_run.instrument == TEST_INSTRUMENT_1
-
-
-def test_script_repo_find(script_repo):
-    """
-    Test find on script repo
-    :param script_repo: ScriptRepo fixture
-    :return: None
-    """
-    found_scripts = script_repo.find(lambda s: s.script == "print('Script 1')")
-
-    assert found_scripts[0] == TEST_SCRIPT
-    assert len(found_scripts) == 1
-
-
-def test_reduction_repo_find(reduction_repo):
-    """
-    Test find on reduction repo
-    :param reduction_repo: reduction repo fixture
-    :return: None
-    """
-    found_reductions = reduction_repo.find(lambda r: r.reduction_state == ReductionState.NOT_STARTED)
-    assert found_reductions[0] == TEST_REDUCTION
-    assert len(found_reductions) == 1
-
-
-def test_run_repo_find(run_repo):
-    """
-    Test find on run repo
-    :param run_repo: run repo fixture
-    :return: None
-    """
-    found_runs = run_repo.find(lambda r: r.instrument.has(Instrument.instrument_name == "instrument 2"))
-    assert found_runs[0] == TEST_RUN_3
-    assert len(found_runs) == 1
-
-    found_runs = run_repo.find(
-        lambda r: r.instrument.has(Instrument.instrument_name == "instrument 1") & (r.title == "Test Run 2")
+@pytest.mark.parametrize(
+    ("order_field,expected_ascending"),
+    [
+        ("run_start", [TEST_REDUCTION_2, TEST_REDUCTION]),
+        ("run_end", [TEST_REDUCTION_2, TEST_REDUCTION]),
+        ("experiment_number", [TEST_REDUCTION_2, TEST_REDUCTION]),
+        ("experiment_title", [TEST_REDUCTION_2, TEST_REDUCTION]),
+    ],
+)
+def test_reductions_by_instrument_sort_by_run_field(reduction_repo, order_field, expected_ascending):
+    """Test reductions by run fields"""
+    expected = expected_ascending
+    result = reduction_repo.find(
+        ReductionSpecification().by_instrument("instrument 1", order_by=order_field, order_direction="asc")
     )
-    assert found_runs[0] == TEST_RUN_2
-    assert len(found_runs) == 1
-
-
-def test_run_repo_find_multiple_filters(run_repo):
-    """
-    Test find with multiple filter expression on run repo
-    :param run_repo: run repo fixture
-    :return: None
-    """
-    found_runs = run_repo.find(
-        lambda r: r.instrument.has(Instrument.instrument_name == "instrument 1") & (r.users == "User1, User2")
+    assert expected == result
+    result = reduction_repo.find(
+        ReductionSpecification().by_instrument("instrument 1", order_by=order_field, order_direction="desc")
     )
-    assert len(found_runs) == 2
-    assert TEST_RUN_1 in found_runs
-    assert TEST_RUN_2 in found_runs
+    expected.reverse()
+    assert expected == result
 
-    found_runs = run_repo.find(
-        lambda r: r.instrument.has(Instrument.instrument_name == "instrument 2") & (r.users == "User1, User2")
+
+def test_reductions_by_instrument_sort_by_reduction_field(reduction_repo):
+    """Test sorting by reduction field"""
+    result = reduction_repo.find(
+        ReductionSpecification().by_instrument("instrument 1", order_by="reduction_state", order_direction="asc")
     )
-    assert len(found_runs) == 1
-    assert TEST_RUN_3 in found_runs
+    expected = [TEST_REDUCTION_2, TEST_REDUCTION]
+    assert result == expected
 
-
-def test_run_repo_find_with_or(run_repo):
-    """
-    Test find with or on run repo
-    :param run_repo: run repo fixture
-    :return: None
-    """
-    found_runs = run_repo.find(
-        lambda r: (r.instrument.has(Instrument.instrument_name == "instrument 1")) | (r.title == "Test Run 3")
+    result = reduction_repo.find(
+        ReductionSpecification().by_instrument("instrument 1", order_by="reduction_state", order_direction="desc")
     )
-    assert len(found_runs) == 3
-    assert TEST_RUN_1 in found_runs
-    assert TEST_RUN_2 in found_runs
-    assert TEST_RUN_3 in found_runs
-
-
-def test_run_repo_find_with_reduction(run_repo):
-    """
-    Test find of run repo based on related reduction
-    :param run_repo: run repo fixture
-    :return: None
-    """
-    found_runs = run_repo.find(lambda r: r.reductions.any(Reduction.reduction_state == ReductionState.NOT_STARTED))
-    assert len(found_runs) == 1
-    assert TEST_RUN_1 in found_runs
-
-
-def test_reduction_repo_find_with_run(reduction_repo):
-    """
-    test reduction repo find based on related instrument
-    :param reduction_repo: reduction repo fixture
-    :return: None
-    """
-    found_reductions = reduction_repo.find(
-        lambda r: r.runs.any(Run.instrument.has(Instrument.instrument_name == "instrument 1"))
-    )
-    assert len(found_reductions) == 1
-    assert TEST_REDUCTION in found_reductions
-
-
-def test_run_repo_order_by_asc(run_repo):
-    """
-    Test ordering on run repo
-    :param run_repo: RunRepo fixture
-    :return: None
-    """
-    runs = run_repo.find(
-        lambda r: r.instrument == TEST_INSTRUMENT_1, order_by="experiment_number", order_direction="asc"
-    )
-    assert runs[0].id == 1
-    assert runs[1].id == 2
-
-
-def test_run_repo_order_by_desc(run_repo):
-    """
-    Test ordering on run repo descending
-    :param run_repo:
-    :return:
-    """
-    runs = run_repo.find(
-        lambda r: r.instrument == TEST_INSTRUMENT_1, order_by="experiment_number", order_direction="desc"
-    )
-    assert runs[0].id == 2
-    assert runs[1].id == 1
-
-
-def test_repo_count_no_filter(run_repo):
-    """
-    Assert count for no filter
-    :param run_repo: repo fixture
-    :return: None
-    """
-    assert run_repo.count() == 3
-
-
-def test_repo_count_with_filter(run_repo):
-    """Assert count for filter"""
-    assert run_repo.count(lambda run: run.instrument == TEST_INSTRUMENT_1) == 2
-
-
-def test_repo_limit_no_filter(run_repo):
-    """Test limit"""
-    assert len(run_repo.find(lambda run: True)) == 3
-    assert len(run_repo.find(lambda run: True, limit=1)) == 1
+    expected.reverse()
+    assert result == expected

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -250,6 +250,23 @@ def test_instrument_reductions_count():
     assert response.json()["count"] == 1
 
 
+def test_instrument_runs_count():
+    """
+    Test instrument runs count
+    :return:
+    """
+    response = client.get("/instrument/TEST/runs/count")
+    assert response.json()["count"] == 1
+
+
+def test_total_runs_count():
+    """
+    Test total runs count
+    """
+    response = client.get("/runs/count")
+    assert response.json()["count"] == 5001
+
+
 def test_readiness_and_liveness_probes():
     """
     Test endpoint for probes

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -267,6 +267,27 @@ def test_total_runs_count():
     assert response.json()["count"] == 5001
 
 
+def test_get_runs_by_instrument():
+    """
+    Test getting runs by instrument
+    :return:
+    """
+    response = client.get("/instrument/TEST/runs")
+    assert len(response.json()) == 1
+    assert response.json()[0] == {
+        "experiment_number": 1820497,
+        "filename": "MAR25581.nxs",
+        "good_frames": 6452,
+        "instrument_name": "TEST",
+        "raw_frames": 8067,
+        "run_end": "2019-03-22T10:18:26",
+        "run_start": "2019-03-22T10:15:44",
+        "title": "Whitebeam - vanadium - detector tests - vacuum bad - HT on not on all LAB",
+        "users": "Wood,Guidi,Benedek,Mansson,Juranyi,Nocerino,Forslund,Matsubara",
+    }
+    assert response.status_code == 200
+
+
 def test_readiness_and_liveness_probes():
     """
     Test endpoint for probes

--- a/test/e2e/test_core.py
+++ b/test/e2e/test_core.py
@@ -196,6 +196,47 @@ def test_get_reductions_for_instrument_reductions_exist():
     ]
 
 
+def test_get_reductions_for_instrument_runs_included():
+    """Test runs are included when requested for given instrument when instrument and reductions exist"""
+    response = client.get("/instrument/test/reductions?include_runs=true")
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": 5001,
+            "reduction_end": None,
+            "reduction_inputs": {
+                "ei": "'auto'",
+                "mask_file_link": "https://raw.githubusercontent.com/pace-neutrons/InstrumentFiles/964733aec28b00b13f32fb61afa363a74dd62130/mari/mari_mask2023_1.xml",
+                "monovan": 0,
+                "remove_bkg": True,
+                "runno": 25581,
+                "sam_mass": 0.0,
+                "sam_rmm": 0.0,
+                "sum_runs": False,
+                "wbvan": 12345,
+            },
+            "reduction_outputs": None,
+            "reduction_start": None,
+            "reduction_state": "NOT_STARTED",
+            "reduction_status_message": None,
+            "runs": [
+                {
+                    "experiment_number": 1820497,
+                    "filename": "MAR25581.nxs",
+                    "good_frames": 6452,
+                    "instrument_name": "TEST",
+                    "raw_frames": 8067,
+                    "run_end": "2019-03-22T10:18:26",
+                    "run_start": "2019-03-22T10:15:44",
+                    "title": "Whitebeam - vanadium - detector tests - vacuum bad - HT " "on not on all LAB",
+                    "users": "Wood,Guidi,Benedek,Mansson,Juranyi,Nocerino,Forslund,Matsubara",
+                }
+            ],
+            "script": None,
+        }
+    ]
+
+
 def test_reductions_by_instrument_no_reductions():
     """
     Test empty array returned when no reductions for instrument

--- a/test/scripts/test_acquisition.py
+++ b/test/scripts/test_acquisition.py
@@ -193,7 +193,7 @@ def test_get_script_for_reduction_no_reduction_id(mock_get_by_name):
 
 
 @patch("ir_api.scripts.acquisition.get_transform_for_instrument")
-@patch("ir_api.scripts.acquisition.ReductionRepo")
+@patch("ir_api.scripts.acquisition.Repo")
 @patch("ir_api.scripts.acquisition.get_by_instrument_name")
 def test_get_script_for_reduction_with_valid_reduction_id(mock_get_by_name, mock_repo, mock_get_transform):
     """
@@ -217,7 +217,7 @@ def test_get_script_for_reduction_with_valid_reduction_id(mock_get_by_name, mock
     assert result == expected_script
 
 
-@patch("ir_api.scripts.acquisition.ReductionRepo")
+@patch("ir_api.scripts.acquisition.Repo")
 @patch("ir_api.scripts.acquisition.get_by_instrument_name", return_value="some instrument")
 def test_get_script_for_reduction_with_invalid_reduction_id(_, mock_repo):
     """


### PR DESCRIPTION
closes #270 
closes #246 
closes #252

This PR does 3 things:
 - Implements the specifications with the repo pattern
 - Adds the new endpoints for the frontend
 - Improves API docs page

The spec and repo, results in a significantly reduced test burden and other benefits discussed. As well as allowing us to more cleanly apply sorting and pagination via simple function and decorator.

For the frontend endpoint changes

It is now possible to filter by run fields that exist on the frontend table from the /instrument/<>/reductions table
The count endpoints have been added
And the endpoint to see all runs for an instrument

Based on now closed #251 


