### PR TITLE
Remove logging from repo.find_one()

### DIFF
--- a/fia_api/core/repositories.py
+++ b/fia_api/core/repositories.py
@@ -75,6 +75,7 @@ class Repo(Generic[T]):
             except NoResultFound:
                 return None
             except MultipleResultsFound as exc:
+                logger.exception("Non unique record found for %s", spec.value)
                 raise NonUniqueRecordError() from exc
 
     def count(self, spec: Specification[T]) -> int:


### PR DESCRIPTION
Closes #542 

## Description
Removing the logging for exceptions from repo's find_one() method, as per description of the issue.