### PR TITLE
Enable FastAPI linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ select = [
     "FLY", # flynt - prefer f string over .format
     "PERF", # Perflint - Flag performance antipatterns
     "RUF", # Ruff specific rules
+    "FAST", # FastAPI rules
 ]
 ignore = [
     "S101", # flake8-bandit - Use of assert (all over pytest tests)


### PR DESCRIPTION
This PR enables Ruff's FastAPI linting rules (FAST). No existing violations were found in this repository.