### PR TITLE
Add caching to instrument and live-data endpoints

### DIFF
--- a/fia_api/routers/instrument.py
+++ b/fia_api/routers/instrument.py
@@ -1,3 +1,4 @@
+import os
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
@@ -5,12 +6,18 @@ from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
 from fia_api.core.auth.tokens import JWTAPIBearer, get_user_from_token
+from fia_api.core.cache import cache_get_json, cache_set_json
 from fia_api.core.exceptions import AuthError
 from fia_api.core.services.instrument import get_latest_run_by_instrument_name, update_latest_run_for_instrument
 from fia_api.core.session import get_db_session
 
 InstrumentRouter = APIRouter(prefix="/instrument")
 jwt_api_security = JWTAPIBearer()
+INSTRUMENT_LATEST_RUN_CACHE_TTL_SECONDS = int(os.environ.get("INSTRUMENT_LATEST_RUN_CACHE_TTL_SECONDS", "15"))
+
+
+def _latest_run_cache_key(instrument: str) -> str:
+    return f"fia_api:instrument:latest_run:{instrument.upper()}"
 
 
 @InstrumentRouter.get("/{instrument}/latest-run", tags=["instrument"])
@@ -30,8 +37,19 @@ async def get_instrument_latest_run(
     if user.role != "staff":
         # If not staff this is not allowed
         raise AuthError("User not authorised for this action")
+
+    if INSTRUMENT_LATEST_RUN_CACHE_TTL_SECONDS > 0:
+        cached = cache_get_json(_latest_run_cache_key(instrument))
+        if isinstance(cached, dict):
+            return cached
+
     latest_run = get_latest_run_by_instrument_name(instrument.upper(), session)
-    return {"latest_run": latest_run}
+    payload = {"latest_run": latest_run}
+
+    if INSTRUMENT_LATEST_RUN_CACHE_TTL_SECONDS > 0:
+        cache_set_json(_latest_run_cache_key(instrument), payload, INSTRUMENT_LATEST_RUN_CACHE_TTL_SECONDS)
+
+    return payload
 
 
 @InstrumentRouter.put("/{instrument}/latest-run", tags=["instrument"])
@@ -55,4 +73,5 @@ async def update_instrument_latest_run(
         # If not staff this is not allowed
         raise AuthError("User not authorised for this action")
     update_latest_run_for_instrument(instrument.upper(), latest_run["latest_run"], session)
+    cache_set_json(_latest_run_cache_key(instrument), None, 1)
     return {"latest_run": latest_run["latest_run"]}

--- a/fia_api/routers/instrument_specs.py
+++ b/fia_api/routers/instrument_specs.py
@@ -1,3 +1,4 @@
+import os
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
@@ -6,12 +7,18 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session
 
 from fia_api.core.auth.tokens import JWTAPIBearer, get_user_from_token
+from fia_api.core.cache import cache_get_json, cache_set_json
 from fia_api.core.exceptions import AuthError
 from fia_api.core.services.instrument import get_specification_by_instrument_name, update_specification_for_instrument
 from fia_api.core.session import get_db_session
 
 InstrumentSpecRouter = APIRouter()
 jwt_api_security = JWTAPIBearer()
+INSTRUMENT_SPEC_CACHE_TTL_SECONDS = int(os.environ.get("INSTRUMENT_SPEC_CACHE_TTL_SECONDS", "120"))
+
+
+def _spec_cache_key(instrument_name: str) -> str:
+    return f"fia_api:instrument:spec:{instrument_name.upper()}"
 
 
 @InstrumentSpecRouter.get(
@@ -32,7 +39,18 @@ async def get_instrument_specification(
     if user.role != "staff":
         # If not staff this is not allowed
         raise AuthError("User not authorised for this action")
-    return get_specification_by_instrument_name(instrument_name.upper(), session)
+
+    if INSTRUMENT_SPEC_CACHE_TTL_SECONDS > 0:
+        cached = cache_get_json(_spec_cache_key(instrument_name))
+        if isinstance(cached, dict):
+            return cached.get("specification")
+
+    specification = get_specification_by_instrument_name(instrument_name.upper(), session)
+
+    if INSTRUMENT_SPEC_CACHE_TTL_SECONDS > 0:
+        cache_set_json(_spec_cache_key(instrument_name), {"specification": specification}, INSTRUMENT_SPEC_CACHE_TTL_SECONDS)
+
+    return specification
 
 
 @InstrumentSpecRouter.put("/instrument/{instrument_name}/specification", tags=["instrument specifications"])
@@ -54,4 +72,5 @@ async def update_instrument_specification(
         # If not staff this is not allowed
         raise AuthError("User not authorised for this action")
     update_specification_for_instrument(instrument_name.upper(), specification, session)
+    cache_set_json(_spec_cache_key(instrument_name), None, 1)
     return specification

--- a/fia_api/routers/instrument_specs.py
+++ b/fia_api/routers/instrument_specs.py
@@ -48,7 +48,9 @@ async def get_instrument_specification(
     specification = get_specification_by_instrument_name(instrument_name.upper(), session)
 
     if INSTRUMENT_SPEC_CACHE_TTL_SECONDS > 0:
-        cache_set_json(_spec_cache_key(instrument_name), {"specification": specification}, INSTRUMENT_SPEC_CACHE_TTL_SECONDS)
+        cache_set_json(
+            _spec_cache_key(instrument_name), {"specification": specification}, INSTRUMENT_SPEC_CACHE_TTL_SECONDS
+        )
 
     return specification
 

--- a/fia_api/routers/live_data.py
+++ b/fia_api/routers/live_data.py
@@ -1,4 +1,5 @@
 # Live Data Script router
+import os
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends
@@ -6,7 +7,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
 from fia_api.core.auth.tokens import JWTAPIBearer, get_user_from_token
-from fia_api.core.cache import cache_get, cache_set_json
+from fia_api.core.cache import cache_get, cache_get_json, cache_set_json
 from fia_api.core.exceptions import AuthError
 from fia_api.core.request_models import LiveDataScriptUpdateRequest
 from fia_api.core.services.instrument import (
@@ -18,6 +19,8 @@ from fia_api.core.session import get_db_session
 
 LiveDataRouter = APIRouter(tags=["live-data"])
 jwt_api_security = JWTAPIBearer()
+LIVE_DATA_INSTRUMENTS_CACHE_TTL_SECONDS = int(os.environ.get("LIVE_DATA_INSTRUMENTS_CACHE_TTL_SECONDS", "120"))
+LIVE_DATA_SCRIPT_CACHE_TTL_SECONDS = int(os.environ.get("LIVE_DATA_SCRIPT_CACHE_TTL_SECONDS", "60"))
 
 
 @LiveDataRouter.get("/live-data/instruments")
@@ -28,7 +31,18 @@ async def get_live_data_instruments(session: Annotated[Session, Depends(get_db_s
     :param session: The current session of the request
     :return: List of instrument names with live data support enabled
     """
-    return get_instruments_with_live_data_support(session)
+    cache_key = "fia_api:live_data:instruments"
+    if LIVE_DATA_INSTRUMENTS_CACHE_TTL_SECONDS > 0:
+        cached = cache_get_json(cache_key)
+        if isinstance(cached, list):
+            return cached
+
+    instruments = get_instruments_with_live_data_support(session)
+
+    if LIVE_DATA_INSTRUMENTS_CACHE_TTL_SECONDS > 0:
+        cache_set_json(cache_key, instruments, LIVE_DATA_INSTRUMENTS_CACHE_TTL_SECONDS)
+
+    return instruments
 
 
 def _get_traceback_key(instrument: str) -> str:
@@ -46,6 +60,10 @@ async def get_instrument_traceback(instrument: str) -> str | None:
     return cache_get(_get_traceback_key(instrument.lower()))
 
 
+def _get_script_cache_key(instrument: str) -> str:
+    return f"fia_api:live_data:script:{instrument.upper()}"
+
+
 @LiveDataRouter.get("/live-data/{instrument}/script")
 async def get_instrument_script(instrument: str, session: Annotated[Session, Depends(get_db_session)]) -> str | None:
     """
@@ -55,7 +73,17 @@ async def get_instrument_script(instrument: str, session: Annotated[Session, Dep
     :param session: The current session of the request
     :return: The live data script or None
     """
-    return get_live_data_script_by_instrument_name(instrument.upper(), session)
+    if LIVE_DATA_SCRIPT_CACHE_TTL_SECONDS > 0:
+        cached = cache_get_json(_get_script_cache_key(instrument))
+        if isinstance(cached, dict):
+            return cached.get("script")
+
+    script = get_live_data_script_by_instrument_name(instrument.upper(), session)
+
+    if LIVE_DATA_SCRIPT_CACHE_TTL_SECONDS > 0:
+        cache_set_json(_get_script_cache_key(instrument), {"script": script}, LIVE_DATA_SCRIPT_CACHE_TTL_SECONDS)
+
+    return script
 
 
 @LiveDataRouter.put("/live-data/{instrument}/script")
@@ -79,6 +107,7 @@ async def update_instrument_script(
         raise AuthError("Only Staff can update Live Data Scripts")
 
     update_live_data_script_for_instrument(instrument.upper(), script_request.value, session)
-    # Clear traceback when script is updated
+    # Clear traceback and script cache when script is updated
     cache_set_json(_get_traceback_key(instrument), None, 1)
+    cache_set_json(_get_script_cache_key(instrument), None, 1)
     return "ok"

--- a/test/e2e/test_endpoint_cache.py
+++ b/test/e2e/test_endpoint_cache.py
@@ -1,0 +1,107 @@
+"""Cache behavior tests for live-data and instrument endpoints."""
+
+from http import HTTPStatus
+from unittest.mock import patch
+
+from starlette.testclient import TestClient
+
+from fia_api.fia_api import app
+
+from .constants import STAFF_HEADER
+
+client = TestClient(app)
+
+
+# --- GET /live-data/instruments ---
+
+
+@patch("fia_api.routers.live_data.LIVE_DATA_INSTRUMENTS_CACHE_TTL_SECONDS", 120)
+@patch("fia_api.routers.live_data.get_instruments_with_live_data_support")
+@patch("fia_api.routers.live_data.cache_set_json")
+@patch("fia_api.routers.live_data.cache_get_json")
+def test_live_data_instruments_cache_hit(mock_cache_get, mock_cache_set, mock_get_instruments):
+    cached_payload = ["INSTRUMENT_1", "INSTRUMENT_2"]
+    mock_cache_get.return_value = cached_payload
+
+    response = client.get("/live-data/instruments")
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == cached_payload
+    mock_get_instruments.assert_not_called()
+    mock_cache_set.assert_not_called()
+
+
+# --- GET /live-data/{instrument}/script ---
+
+
+@patch("fia_api.routers.live_data.LIVE_DATA_SCRIPT_CACHE_TTL_SECONDS", 60)
+@patch("fia_api.routers.live_data.get_live_data_script_by_instrument_name")
+@patch("fia_api.routers.live_data.cache_set_json")
+@patch("fia_api.routers.live_data.cache_get_json")
+def test_live_data_script_cache_hit(mock_cache_get, mock_cache_set, mock_get_script):
+    mock_cache_get.return_value = {"script": "print('hello')"}
+
+    response = client.get("/live-data/TEST/script")
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == "print('hello')"
+    mock_get_script.assert_not_called()
+    mock_cache_set.assert_not_called()
+
+
+@patch("fia_api.routers.live_data.LIVE_DATA_SCRIPT_CACHE_TTL_SECONDS", 60)
+@patch("fia_api.routers.live_data.get_live_data_script_by_instrument_name")
+@patch("fia_api.routers.live_data.cache_set_json")
+@patch("fia_api.routers.live_data.cache_get_json")
+def test_live_data_script_cache_hit_none_script(mock_cache_get, mock_cache_set, mock_get_script):
+    """A cached None script (instrument has no script) should still be a cache hit."""
+    mock_cache_get.return_value = {"script": None}
+
+    response = client.get("/live-data/TEST/script")
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() is None
+    mock_get_script.assert_not_called()
+    mock_cache_set.assert_not_called()
+
+
+# --- GET /instrument/{instrument_name}/specification ---
+
+
+@patch("fia_api.routers.instrument_specs.INSTRUMENT_SPEC_CACHE_TTL_SECONDS", 120)
+@patch("fia_api.core.auth.tokens.requests.post")
+@patch("fia_api.routers.instrument_specs.get_specification_by_instrument_name")
+@patch("fia_api.routers.instrument_specs.cache_set_json")
+@patch("fia_api.routers.instrument_specs.cache_get_json")
+def test_instrument_spec_cache_hit(mock_cache_get, mock_cache_set, mock_get_spec, mock_post):
+    cached_spec = {"foo": "bar", "baz": 42}
+    mock_cache_get.return_value = {"specification": cached_spec}
+    mock_post.return_value.status_code = HTTPStatus.OK
+
+    response = client.get("/instrument/TEST/specification", headers=STAFF_HEADER)
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == cached_spec
+    mock_get_spec.assert_not_called()
+    mock_cache_set.assert_not_called()
+
+
+# --- GET /instrument/{instrument}/latest-run ---
+
+
+@patch("fia_api.routers.instrument.INSTRUMENT_LATEST_RUN_CACHE_TTL_SECONDS", 15)
+@patch("fia_api.core.auth.tokens.requests.post")
+@patch("fia_api.routers.instrument.get_latest_run_by_instrument_name")
+@patch("fia_api.routers.instrument.cache_set_json")
+@patch("fia_api.routers.instrument.cache_get_json")
+def test_instrument_latest_run_cache_hit(mock_cache_get, mock_cache_set, mock_get_latest, mock_post):
+    cached_payload = {"latest_run": "12345"}
+    mock_cache_get.return_value = cached_payload
+    mock_post.return_value.status_code = HTTPStatus.OK
+
+    response = client.get("/instrument/TEST/latest-run", headers=STAFF_HEADER)
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == cached_payload
+    mock_get_latest.assert_not_called()
+    mock_cache_set.assert_not_called()


### PR DESCRIPTION
Closes # <!-- Issue # here -->

## Description

<p>Adds Valkey caching to four endpoints that previously hit the database on every request despite returning data that rarely changes. This follows the same cache-aside pattern already established for the job list/count endpoints in <code>jobs.py</code>.</p>
<h3>Cached endpoints</h3>

Endpoint | TTL | Cache key | Invalidated by
-- | -- | -- | --
GET /live-data/instruments | 120s | fia_api:live_data:instruments | TTL expiry only
GET /live-data/{instrument}/script | 60s | fia_api:live_data:script:{INSTRUMENT} | PUT /live-data/{instrument}/script
GET /instrument/{name}/specification | 120s | fia_api:instrument:spec:{NAME} | PUT /instrument/{name}/specification
GET /instrument/{instrument}/latest-run | 15s | fia_api:instrument:latest_run:{INSTRUMENT} | PUT /{instrument}/latest-run

<h3>How it works</h3>
<p>Each GET endpoint checks Valkey for a cached response before querying PostgreSQL. On a cache miss, the DB result is stored in Valkey with a TTL. When the corresponding PUT endpoint is called (e.g. a staff member updates a live data script), the cache entry is immediately invalidated by writing <code>None</code> with a 1-second TTL, so the next GET fetches fresh data from the database.</p>
<p>For endpoints where the value can legitimately be <code>None</code> (live data script, instrument specification), the cached value is wrapped in a dict (e.g. <code>{"script": value}</code>) so that a cache miss (<code>None</code> from Valkey) can be distinguished from a cached <code>None</code> value.</p>

<h3>Why this is useful</h3>
<ul>
<li><strong>Live data instruments</strong> — The list of instruments with live data support only changes when an admin enables/disables an instrument. Without caching, every page load of the live data view queries the <code>instruments</code> table.</li>
<li><strong>Live data scripts</strong> — Scripts are updated infrequently by staff. The live data viewer polls this endpoint, meaning the same script is fetched from the database repeatedly for no reason.</li>
<li><strong>Instrument specifications</strong> — Configuration data that only changes via explicit staff PUT calls. Cached with a longer TTL since changes are rare.</li>
<li><strong>Instrument latest run</strong> — Changes more frequently (updated when new data arrives from the beamline), so it has a shorter 15s TTL. This endpoint is polled by the frontend instrument status view.</li>
</ul>

<h3>Configuration</h3>
<p>All TTLs are configurable via environment variables and default to sensible values:</p>
<pre><code>LIVE_DATA_INSTRUMENTS_CACHE_TTL_SECONDS=120
LIVE_DATA_SCRIPT_CACHE_TTL_SECONDS=60
INSTRUMENT_SPEC_CACHE_TTL_SECONDS=120
INSTRUMENT_LATEST_RUN_CACHE_TTL_SECONDS=15
</code></pre>
<p>Setting any of these to <code>0</code> disables caching for that endpoint (matching the existing pattern for <code>JOB_LIST_CACHE_TTL_SECONDS</code>).</p>
<h3>Testing locally</h3>

```bash
# Run the new cache-hit tests
pytest test/e2e/test_endpoint_cache.py -v
```

<p>The new tests mock <code>cache_get_json</code> to return a cached payload and assert that the underlying DB service function is never called, confirming the cache-hit path works correctly. There is also a test for the edge case where a <code>None</code> script is cached.</p>

<h3>Manual verification with a local Valkey instance</h3>

If you want to test the caching behaviour against a real Valkey server rather than relying on the mocked unit tests:

```bash
# Start a Valkey container from WSL
docker run -d --name valkey -p 6379:6379 valkey/valkey:latest

# Set the env var so the API connects to it
export VALKEY_URL=redis://localhost:6379/0

# Start the API in dev mode
DEV_MODE=1 uvicorn fia_api.fia_api:app --reload
```

You can then watch cache keys being set and expiring:

```bash
# In another terminal, connect to the Valkey CLI
docker exec -it valkey valkey-cli

# Monitor all commands in real time
127.0.0.1:6379> MONITOR

# Or inspect specific keys
127.0.0.1:6379> KEYS fia_api:*
127.0.0.1:6379> TTL fia_api:live_data:instruments
127.0.0.1:6379> GET fia_api:live_data:instruments
```

Calling `GET /live-data/instruments` twice should show a `SETEX` on the first call and a `GET` hit on the second. Calling the corresponding `PUT` endpoint should show the key being invalidated.

<h3>Test plan</h3>
<ul>
<li>[ ] New cache-hit tests pass (<code>test/e2e/test_endpoint_cache.py</code> — 5 tests)</li>
<li>[ ] Existing unit tests unaffected (158 passed)</li>
<li>[ ] E2E tests pass with live DB and Valkey</li>
<li>[ ] Verify each PUT endpoint invalidates the corresponding cache (next GET returns fresh data)</li>
<li>[ ] Verify setting a TTL env var to <code>0</code> disables caching for that endpoint</li>
</ul></body></html><!--EndFragment-->

</body>
</html>
